### PR TITLE
refactor: clean up @mogami/solana by removing inline exports from main class

### DIFF
--- a/libs/solana/src/index.ts
+++ b/libs/solana/src/index.ts
@@ -1,2 +1,3 @@
+export * from './lib/helpers'
 export * from './lib/solana'
-export * from './lib/helpers/parse-endpoint'
+export * from './lib/interfaces'

--- a/libs/solana/src/lib/helpers/get-public-key.spec.ts
+++ b/libs/solana/src/lib/helpers/get-public-key.spec.ts
@@ -1,0 +1,18 @@
+import { PublicKey } from '@solana/web3.js'
+import { getPublicKey } from './get-public-key'
+
+const DEMO_KEY = 'Don8L4DTVrUrRAcVTsFoCRqei5Mokde3CV3K9Ut4nAGZ'
+
+describe('getPublicKey', () => {
+  it('should accept a string', () => {
+    const publicKey = getPublicKey(DEMO_KEY)
+
+    expect(publicKey.toBase58()).toEqual(DEMO_KEY)
+  })
+
+  it('should accept a PublicKey', () => {
+    const publicKey = getPublicKey(new PublicKey(DEMO_KEY))
+
+    expect(publicKey.toBase58()).toEqual(DEMO_KEY)
+  })
+})

--- a/libs/solana/src/lib/helpers/get-public-key.ts
+++ b/libs/solana/src/lib/helpers/get-public-key.ts
@@ -1,0 +1,9 @@
+import { PublicKey } from '@solana/web3.js'
+import { PublicKeyString } from '../interfaces'
+
+export function getPublicKey(account: PublicKeyString): PublicKey {
+  if (typeof account === 'string') {
+    return new PublicKey(account)
+  }
+  return account
+}

--- a/libs/solana/src/lib/helpers/index.ts
+++ b/libs/solana/src/lib/helpers/index.ts
@@ -1,0 +1,2 @@
+export * from './get-public-key'
+export * from './parse-endpoint'

--- a/libs/solana/src/lib/interfaces/index.ts
+++ b/libs/solana/src/lib/interfaces/index.ts
@@ -1,0 +1,4 @@
+export * from './public-key-string'
+export * from './solana-config'
+export * from './solana-logger'
+export * from './token-balance'

--- a/libs/solana/src/lib/interfaces/public-key-string.ts
+++ b/libs/solana/src/lib/interfaces/public-key-string.ts
@@ -1,0 +1,3 @@
+import { PublicKey } from '@solana/web3.js'
+
+export type PublicKeyString = PublicKey | string

--- a/libs/solana/src/lib/interfaces/solana-config.ts
+++ b/libs/solana/src/lib/interfaces/solana-config.ts
@@ -1,0 +1,5 @@
+import { SolanaLogger } from './solana-logger'
+
+export interface SolanaConfig {
+  logger?: SolanaLogger
+}

--- a/libs/solana/src/lib/interfaces/token-balance.ts
+++ b/libs/solana/src/lib/interfaces/token-balance.ts
@@ -1,0 +1,7 @@
+import BigNumber from 'bignumber.js'
+import { PublicKeyString } from './public-key-string'
+
+export interface TokenBalance {
+  account: PublicKeyString
+  balance: BigNumber
+}

--- a/libs/solana/src/lib/solana.ts
+++ b/libs/solana/src/lib/solana.ts
@@ -1,25 +1,7 @@
 import { Commitment, Connection, PublicKey } from '@solana/web3.js'
 import BigNumber from 'bignumber.js'
-import { parseEndpoint } from './helpers/parse-endpoint'
-import { SolanaLogger } from './interfaces/solana-logger'
-
-export interface SolanaConfig {
-  logger?: SolanaLogger
-}
-
-export type PublicKeyString = PublicKey | string
-
-export interface TokenBalance {
-  account: PublicKeyString
-  balance: BigNumber
-}
-
-export function getPublicKey(account: PublicKeyString): PublicKey {
-  if (typeof account === 'string') {
-    return new PublicKey(account)
-  }
-  return account
-}
+import { getPublicKey, parseEndpoint } from './helpers'
+import { PublicKeyString, SolanaConfig, TokenBalance } from './interfaces'
 
 export class Solana {
   readonly endpoint: string


### PR DESCRIPTION
@RamirezAlex just some cleanup here. It's probably good we don't export multiple objects from a single file unless there's a compelling reason to.