### PR TITLE
refactor: move @nestjs/serve-static from AppModule to ApiCoreFeatureModule

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -1,26 +1,7 @@
-import { Logger, Module } from '@nestjs/common'
 import { ApiCoreFeatureModule } from '@mogami/api/core/feature'
-import { ServeStaticModule } from '@nestjs/serve-static'
-import { ensureDirSync, existsSync, writeFileSync } from 'fs-extra'
-import { join } from 'path'
-
-const rootPath = join(__dirname, '..', 'admin')
+import { Module } from '@nestjs/common'
 
 @Module({
-  imports: [
-    ApiCoreFeatureModule,
-    ServeStaticModule.forRoot({
-      rootPath,
-      exclude: ['/api/*', '/graphql'],
-    }),
-  ],
+  imports: [ApiCoreFeatureModule],
 })
-export class AppModule {
-  constructor() {
-    if (!existsSync(rootPath)) {
-      ensureDirSync(rootPath)
-      writeFileSync(join(rootPath, 'index.html'), `<pre>Mogami Api</pre>`)
-      Logger.verbose(`Created static root path ${rootPath}`)
-    }
-  }
-}
+export class AppModule {}

--- a/libs/api/core/feature/src/index.ts
+++ b/libs/api/core/feature/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/api-core-feature.controller'
 export * from './lib/api-core-feature.module'
+export { serveStaticFactory } from './lib/serve-static.factory'

--- a/libs/api/core/feature/src/lib/api-core-feature.module.ts
+++ b/libs/api/core/feature/src/lib/api-core-feature.module.ts
@@ -6,9 +6,11 @@ import { ApiTransactionFeatureModule } from '@mogami/api/transaction/feature'
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo'
 import { Module } from '@nestjs/common'
 import { GraphQLModule } from '@nestjs/graphql'
+import { ServeStaticModule } from '@nestjs/serve-static'
 import { join } from 'path'
 import { ApiCoreFeatureController } from './api-core-feature.controller'
 import { ApiCoreFeatureResolver } from './api-core-feature.resolver'
+import { serveStaticFactory } from './serve-static.factory'
 
 @Module({
   controllers: [ApiCoreFeatureController],
@@ -19,6 +21,7 @@ import { ApiCoreFeatureResolver } from './api-core-feature.resolver'
       context: ({ req, res }) => ({ req, res }),
       driver: ApolloDriver,
     }),
+    ServeStaticModule.forRootAsync({ useFactory: serveStaticFactory() }),
     ApiAccountFeatureModule,
     ApiAirdropFeatureModule,
     ApiConfigFeatureModule,

--- a/libs/api/core/feature/src/lib/serve-static.factory.ts
+++ b/libs/api/core/feature/src/lib/serve-static.factory.ts
@@ -1,0 +1,24 @@
+import { Logger } from '@nestjs/common'
+import { ServeStaticModuleOptions } from '@nestjs/serve-static/dist/interfaces/serve-static-options.interface'
+import { existsSync } from 'fs-extra'
+import { join } from 'path'
+
+export function serveStaticFactory() {
+  return function (): ServeStaticModuleOptions[] {
+    const rootPath = join(__dirname, '..', 'admin')
+    const rootExists = existsSync(rootPath)
+
+    if (!rootExists) {
+      Logger.verbose(`Static Hosting disabled: root path does not exist: ${rootPath}.`)
+      return []
+    }
+
+    Logger.verbose(`Static Hosting enabled for: ${rootPath}.`)
+    return [
+      {
+        rootPath,
+        exclude: ['/api/*', '/graphql'],
+      },
+    ]
+  }
+}


### PR DESCRIPTION
This setup should live in the ApiCoreFeature. Also, the previous implementation would create an empty `index.html` if the `rootPath` was not found, this implementation disables static hosting which seems cleaner.