### PR TITLE
fix: make sure admin can create and delete the same app multiple times

### DIFF
--- a/apps/api-e2e/src/integration/app-feature-resolver.spec.ts
+++ b/apps/api-e2e/src/integration/app-feature-resolver.spec.ts
@@ -140,6 +140,23 @@ describe('App (e2e)', () => {
             expect(data.index).toEqual(appIndex)
           })
       })
+
+      it('should create and delete the same app multiple times', async () => {
+        const index = randomAppIndex()
+        const input: AppCreateInput = { index, name: `App ${index}` }
+
+        // Create First
+        const created1 = await runGraphQLQueryAdmin(app, token, CreateApp, { input })
+
+        // Delete First
+        await runGraphQLQueryAdmin(app, token, DeleteApp, { appId: created1.body?.data?.created?.id })
+
+        // Create Second
+        const created2 = await runGraphQLQueryAdmin(app, token, CreateApp, { input })
+
+        // Delete Second
+        await runGraphQLQueryAdmin(app, token, DeleteApp, { appId: created2.body?.data?.created?.id })
+      })
     })
 
     describe('AppUsers', () => {

--- a/libs/api/app/data-access/src/lib/api-app-data-access.service.ts
+++ b/libs/api/app/data-access/src/lib/api-app-data-access.service.ts
@@ -59,6 +59,8 @@ export class ApiAppDataAccessService {
 
   async deleteApp(userId: string, appId: string) {
     await this.ensureAppById(userId, appId)
+    await this.data.appDomain.deleteMany({ where: { env: { appId } } })
+    await this.data.appEnv.deleteMany({ where: { appId } })
     await this.data.appUser.deleteMany({ where: { appId } })
     return this.data.app.delete({ where: { id: appId } })
   }


### PR DESCRIPTION
This patch allows admins to create and delete an app with the same index multiple times.

Before this patch this wasn't possible because of the unique constraint on the hostname, which is based on the appIndex.

This patch makes sure the appEnv and appDomain are cleaned up.