### PR TITLE
chore: change Docker image to mogami dev container

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,9 +38,8 @@ jobs:
         ports: ['5432:5432']
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       solana:
-        image: solanalabs/solana:v1.9.9
+        image: ghcr.io/kin-labs/mogami-solana-network:latest
         ports: ['8899:8899', '8900:8900']
-        options: --entrypoint="solana-test-validator"
     steps:
       - uses: actions/checkout@v3
         name: Checkout [main]


### PR DESCRIPTION
This got merged before https://github.com/kin-labs/mogami/pull/118 but it's somehow reversed, and it's unclear why. We also don't know if we accidentally missed/reversed other commits. 