### PR TITLE
chore: add Docker container for Mogami Solana Network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,15 @@ services:
   postgres:
     image: postgres
     ports:
-      - 5432:5432
+      - '5432:5432'
     environment:
       POSTGRES_DB: prisma
       POSTGRES_USER: prisma
       POSTGRES_PASSWORD: prisma
     volumes:
       - ./tmp/postgres:/var/lib/postgresql/data
+  solana:
+    image: ghcr.io/kin-labs/mogami-solana-network
+    ports:
+      - '8899:8899'
+      - '8900:8900'

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "dev:demo": "nx serve demo",
     "dev:sdk": "nodemon --watch ./api-swagger.json -x 'yarn build:sdk'",
     "dev:services": "docker compose up",
+    "dev:services:postgres": "docker compose up postgres",
+    "dev:services:solana": "docker compose up solana",
     "docker:build": "docker build . -t ghcr.io/kin-labs/mogami",
     "docker:push": "docker push ghcr.io/kin-labs/mogami",
     "docker:run": "docker run -it -p 8000:3000 ghcr.io/kin-labs/mogami",


### PR DESCRIPTION
Adding the container to the docker-compose so it makes it easier to spin up a local development environment.