### PR TITLE
fix: docker container can't start because prisma file is not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,8 @@ FROM base as final
 
 #RUN apk --no-cache add krb5-libs
 
+COPY libs/api/core/data-access/src/prisma/schema.prisma /workspace/libs/api/core/data-access/src/prisma/schema.prisma
+
 # Copy over artifacts from builder image
 COPY --from=builder /workspace/dist /workspace/dist
 


### PR DESCRIPTION
```
2022-06-25T16:45:06.220363+00:00 app[web.1]: yarn run v1.22.18
2022-06-25T16:45:06.248357+00:00 app[web.1]: $ yarn prisma db push && node dist/apps/api/main.js
2022-06-25T16:45:06.746253+00:00 app[web.1]: $ /workspace/node_modules/.bin/prisma db push
2022-06-25T16:45:08.093275+00:00 app[web.1]: Error: Provided schema path `libs/api/core/data-access/src/prisma/schema.prisma` from `package.json` doesn't exist.
2022-06-25T16:45:08.109298+00:00 app[web.1]: error Command failed with exit code 1.
2022-06-25T16:45:08.109415+00:00 app[web.1]: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
2022-06-25T16:45:08.130670+00:00 app[web.1]: error Command failed with exit code 1.
2022-06-25T16:45:08.130772+00:00 app[web.1]: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
2022-06-25T16:45:08.252092+00:00 heroku[web.1]: Process exited with status 1
2022-06-25T16:45:08.371905+00:00 heroku[web.1]: State changed from starting to crashed
```