### PR TITLE
fix: remove trailing slash for custom endpoint

### DIFF
--- a/libs/sdk/src/lib/helpers/parse-kinetic-sdk-config.spec.ts
+++ b/libs/sdk/src/lib/helpers/parse-kinetic-sdk-config.spec.ts
@@ -1,0 +1,37 @@
+import { KineticSdkConfig } from '../interfaces'
+import { parseKineticSdkConfig } from './parse-kinetic-sdk-config'
+
+const baseConfig: KineticSdkConfig = {
+  environment: 'devnet',
+  index: 1,
+}
+
+describe('parseKineticSdkConfig', () => {
+  it('should return a default devnet endpoint', () => {
+    const parsed = parseKineticSdkConfig(baseConfig)
+    expect(parsed.index).toEqual(1)
+    expect(parsed.environment).toEqual('devnet')
+    expect(parsed.endpoint).toEqual('devnet')
+  })
+
+  it('should return a default mainnet endpoint', () => {
+    const parsed = parseKineticSdkConfig({ ...baseConfig, environment: 'mainnet' })
+    expect(parsed.index).toEqual(1)
+    expect(parsed.environment).toEqual('mainnet')
+    expect(parsed.endpoint).toEqual('mainnet')
+  })
+
+  it('should return a custom endpoint', () => {
+    const parsed = parseKineticSdkConfig({ ...baseConfig, endpoint: 'http://localhost:3000' })
+    expect(parsed.index).toEqual(1)
+    expect(parsed.environment).toEqual('devnet')
+    expect(parsed.endpoint).toEqual('http://localhost:3000')
+  })
+
+  it('should remove trailing slashes from endpoint', () => {
+    const parsed = parseKineticSdkConfig({ ...baseConfig, endpoint: 'http://localhost:3000/////' })
+    expect(parsed.index).toEqual(1)
+    expect(parsed.environment).toEqual('devnet')
+    expect(parsed.endpoint).toEqual('http://localhost:3000')
+  })
+})

--- a/libs/sdk/src/lib/helpers/parse-kinetic-sdk-config.ts
+++ b/libs/sdk/src/lib/helpers/parse-kinetic-sdk-config.ts
@@ -1,6 +1,10 @@
 import { KineticSdkConfig } from '../interfaces'
 import { KineticSdkConfigParsed } from '../interfaces/kinetic-sdk-config-parsed'
 
+function removeTrailingSlash(str: string) {
+  return str.replace(/\/+$/, '')
+}
+
 /**
  * This method accepts a Kinetic Sdk Config and will fill in any missing defaults
  * @param {KineticSdkConfig} config
@@ -14,6 +18,6 @@ export function parseKineticSdkConfig(config: KineticSdkConfig): KineticSdkConfi
 
   return {
     ...config,
-    endpoint,
+    endpoint: removeTrailingSlash(endpoint),
   }
 }


### PR DESCRIPTION
This patch fixes an issue with the SDK not initializing when using an endpoint that ends with a slash.