### PR TITLE
chore: only build Docker container on dev and main branches

### DIFF
--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -1,7 +1,6 @@
 name: build-publish-docker
 
 on:
-  pull_request:
   push:
     branches:
       - dev
@@ -50,12 +49,4 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          labels: ${{ steps.meta.outputs.labels }}
-      - name: Build and push Docker (pr)
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        if: github.ref != 'refs/heads/dev' && github.ref != 'refs/heads/main'
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
We don't need to create images on PR as they count to our usage and they need manual cleanup. 

If we want to test an image of a PR we can always manually push it up.