### PR TITLE
refactor: organize addDecimals, kinToQuarks, etc and add tests

### DIFF
--- a/libs/sdk/src/lib/helpers/index.ts
+++ b/libs/sdk/src/lib/helpers/index.ts
@@ -1,4 +1,3 @@
-export * from './add-decimals'
 export * from './get-solana-rpc-endpoint'
 export * from './kin-to-quarks'
 export * from './parse-kinetic-sdk-endpoint'

--- a/libs/sdk/src/lib/helpers/kin-to-quarks.spec.ts
+++ b/libs/sdk/src/lib/helpers/kin-to-quarks.spec.ts
@@ -1,0 +1,28 @@
+import BigNumber from 'bignumber.js'
+import { kinToQuarks, quarksToKin } from './kin-to-quarks'
+
+describe('kinToQuarks and quarksToKin', () => {
+  it('should convert kin to quarks and back ', () => {
+    const validCases = new Map<string, string>([
+      ['0.00001', '1'],
+      ['0.00002', '2'],
+      ['1', '1e5'],
+      ['2', '2e5'],
+      // 10 trillion, more than what's in cicrulation
+      ['10000000000000', '1e18'],
+    ])
+    validCases.forEach((expected, input) => {
+      expect(kinToQuarks(input)).toStrictEqual(new BigNumber(expected))
+      expect(quarksToKin(expected)).toStrictEqual(new BigNumber(input).toString())
+    })
+
+    const roundedCases = new Map<string, string>([
+      ['0.000001', '0'],
+      ['0.000015', '1'],
+      ['0.000018', '1'],
+    ])
+    roundedCases.forEach((expected, input) => {
+      expect(kinToQuarks(input)).toStrictEqual(new BigNumber(expected))
+    })
+  })
+})

--- a/libs/sdk/src/lib/helpers/kin-to-quarks.ts
+++ b/libs/sdk/src/lib/helpers/kin-to-quarks.ts
@@ -1,7 +1,11 @@
+import { addDecimals, removeDecimals } from '@kin-kinetic/solana'
+export { addDecimals, removeDecimals } from '@kin-kinetic/solana'
 import BigNumber from 'bignumber.js'
-import { addDecimals } from './add-decimals'
+
+export function quarksToKin(amount: string): string {
+  return removeDecimals(amount, 5)
+}
 
 export function kinToQuarks(amount: string): BigNumber {
-  console.warn(`[KinToQuarks] Deprecated method: use 'addDecimals(amount, 5)' instead.`)
   return addDecimals(amount, 5)
 }

--- a/libs/sdk/src/lib/helpers/serialize-make-transfer-batch-transactions.ts
+++ b/libs/sdk/src/lib/helpers/serialize-make-transfer-batch-transactions.ts
@@ -1,11 +1,9 @@
+import { Keypair } from '@kin-kinetic/keypair'
+import { addDecimals, Destination, getPublicKey, PublicKeyString } from '@kin-kinetic/solana'
 import { TransactionType } from '@kin-tools/kin-memo'
 import { generateKinMemoInstruction } from '@kin-tools/kin-transaction'
-import { Keypair } from '@kin-kinetic/keypair'
-import { getPublicKey, Destination, PublicKeyString } from '@kin-kinetic/solana'
 import { createTransferInstruction, getAssociatedTokenAddress, TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import { PublicKey, Transaction, TransactionInstruction } from '@solana/web3.js'
-import BigNumber from 'bignumber.js'
-import { addDecimals } from './add-decimals'
 
 export async function serializeMakeTransferBatchTransactions({
   appIndex,

--- a/libs/sdk/src/lib/helpers/serialize-make-transfer-transaction.ts
+++ b/libs/sdk/src/lib/helpers/serialize-make-transfer-transaction.ts
@@ -1,10 +1,9 @@
 import { Keypair } from '@kin-kinetic/keypair'
-import { getPublicKey, PublicKeyString } from '@kin-kinetic/solana'
+import { addDecimals, getPublicKey, PublicKeyString } from '@kin-kinetic/solana'
 import { TransactionType } from '@kin-tools/kin-memo'
 import { generateKinMemoInstruction } from '@kin-tools/kin-transaction'
 import { createTransferInstruction, getAssociatedTokenAddress, TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import { Transaction, TransactionInstruction } from '@solana/web3.js'
-import { addDecimals } from './add-decimals'
 
 export async function serializeMakeTransferTransaction({
   amount,

--- a/libs/solana/src/lib/helpers/add-remove-decimals.spec.ts
+++ b/libs/solana/src/lib/helpers/add-remove-decimals.spec.ts
@@ -1,0 +1,53 @@
+import BigNumber from 'bignumber.js'
+import { addDecimals, removeDecimals } from './add-remove-decimals'
+
+describe('addDecimals and removeDecimals', () => {
+  it('should add decimals and remove them again ', () => {
+    const decimals = 5
+    const validCases = new Map<string, string>([
+      ['0.00001', '1'],
+      ['0.00002', '2'],
+      ['1', '1e5'],
+      ['2', '2e5'],
+      // 10 trillion, more than what's in circulation
+      ['10000000000000', '1e18'],
+    ])
+    validCases.forEach((expected, input) => {
+      expect(addDecimals(input, decimals)).toStrictEqual(new BigNumber(expected))
+      expect(removeDecimals(expected, decimals)).toStrictEqual(new BigNumber(input).toString())
+    })
+
+    const roundedCases = new Map<string, string>([
+      ['0.000001', '0'],
+      ['0.000015', '1'],
+      ['0.000018', '1'],
+    ])
+    roundedCases.forEach((expected, input) => {
+      expect(addDecimals(input, decimals)).toStrictEqual(new BigNumber(expected))
+    })
+  })
+
+  it('should work with different decimals ', () => {
+    const decimals = 2
+    const validCases = new Map<string, string>([
+      ['0.01', '1'],
+      ['0.02', '2'],
+      ['1', '1e2'],
+      ['2', '2e2'],
+      ['10000000000000', '1e15'],
+    ])
+    validCases.forEach((expected, input) => {
+      expect(addDecimals(input, decimals)).toStrictEqual(new BigNumber(expected))
+      expect(removeDecimals(expected, decimals)).toStrictEqual(new BigNumber(input).toString())
+    })
+
+    const roundedCases = new Map<string, string>([
+      ['0.001', '0'],
+      ['0.015', '1'],
+      ['0.018', '1'],
+    ])
+    roundedCases.forEach((expected, input) => {
+      expect(addDecimals(input, decimals)).toStrictEqual(new BigNumber(expected))
+    })
+  })
+})

--- a/libs/solana/src/lib/helpers/add-remove-decimals.ts
+++ b/libs/solana/src/lib/helpers/add-remove-decimals.ts
@@ -4,3 +4,7 @@ export function addDecimals(amount: string, decimals: number): BigNumber {
   const b = new BigNumber(amount).decimalPlaces(decimals, BigNumber.ROUND_DOWN)
   return b.multipliedBy(Math.pow(10, decimals))
 }
+
+export function removeDecimals(amount: BigNumber | string, decimals: number): string {
+  return new BigNumber(amount).dividedBy(Math.pow(10, decimals)).toString()
+}

--- a/libs/solana/src/lib/helpers/index.ts
+++ b/libs/solana/src/lib/helpers/index.ts
@@ -1,3 +1,4 @@
+export * from './add-remove-decimals'
 export * from './convert-commitment'
 export * from './get-public-key'
 export * from './parse-and-sign-token-transfer'


### PR DESCRIPTION
This PR changes how the `kinToQuarks` / `quarksToKin` and the underlying tools work.

- `addDecimals` / `removeDecimals` are moved to `@kin-kinetic/solana` as we need them there in a follow-up PR.
- `kinToQuarks` / `quarksToKin` are now exported from `@kin-kinetic/sdk` has higher-level utilities, basically currying the above functions with `5` decimals. This also ensures compatibility with the ecosystem that depends on these helpers.

I also migrated the tests from the `kin-node` sdk. 