### PR TITLE
refactor: provide lastValidBlockHeight with the transaction

### DIFF
--- a/libs/sdk/src/lib/kinetic-sdk-internal.ts
+++ b/libs/sdk/src/lib/kinetic-sdk-internal.ts
@@ -73,10 +73,13 @@ export class KineticSdkInternal {
       throw new Error(`AppConfig not initialized`)
     }
     mint = mint || this.appConfig.mint.publicKey
-    const { mintPublicKey, mintFeePayer, latestBlockhash } = await this.prepareTransaction({ mint })
+    const { lastValidBlockHeight, latestBlockhash, mintFeePayer, mintPublicKey } = await this.prepareTransaction({
+      mint,
+    })
 
     const tx = await serializeCreateAccountTransaction({
       appIndex: this.appConfig.app.index,
+      lastValidBlockHeight,
       latestBlockhash,
       mintFeePayer,
       mintPublicKey,
@@ -135,7 +138,7 @@ export class KineticSdkInternal {
       throw new Error(`AppConfig not initialized`)
     }
     mint = mint || this.appConfig.mint.publicKey
-    const { mintDecimals, mintPublicKey, mintFeePayer, latestBlockhash, lastValidBlockHeight } =
+    const { lastValidBlockHeight, latestBlockhash, mintDecimals, mintFeePayer, mintPublicKey } =
       await this.prepareTransaction({
         mint,
       })
@@ -144,6 +147,7 @@ export class KineticSdkInternal {
       amount,
       appIndex: this.appConfig.app.index,
       destination,
+      lastValidBlockHeight,
       latestBlockhash,
       mintDecimals,
       mintFeePayer,
@@ -156,8 +160,8 @@ export class KineticSdkInternal {
       commitment: commitment || Commitment.Confirmed,
       environment: this.appConfig.environment.name,
       index: this.appConfig.app.index,
-      mint: mint.toString(),
       lastValidBlockHeight,
+      mint: mint.toString(),
       referenceId: referenceId || null,
       referenceType: referenceType || null,
       tx: tx.toString('base64'),
@@ -191,6 +195,7 @@ export class KineticSdkInternal {
     const tx = await serializeMakeTransferBatchTransactions({
       appIndex: this.appConfig.app.index,
       destinations,
+      lastValidBlockHeight,
       latestBlockhash,
       mintDecimals,
       mintFeePayer,
@@ -203,8 +208,8 @@ export class KineticSdkInternal {
       commitment: commitment || Commitment.Confirmed,
       environment: this.appConfig.environment.name,
       index: this.appConfig.app.index,
-      mint: mint.toString(),
       lastValidBlockHeight,
+      mint: mint.toString(),
       referenceId: referenceId || null,
       referenceType: referenceType || null,
       tx: tx.toString('base64'),

--- a/libs/solana/src/lib/helpers/parse-and-sign-token-transfer.ts
+++ b/libs/solana/src/lib/helpers/parse-and-sign-token-transfer.ts
@@ -21,6 +21,9 @@ export function parseAndSignTokenTransfer({ tx, signer }: { tx: Buffer; signer: 
     throw new Error(`parseAndSignTokenTransfer: Can't find token transfer instruction`)
   }
 
+  if (!transaction.recentBlockhash) {
+    throw new Error(`parseAndSignTokenTransfer: Can't find recentBlockhash`)
+  }
   // Get the amount and destination from the instruction
   const {
     data: { amount },
@@ -29,8 +32,7 @@ export function parseAndSignTokenTransfer({ tx, signer }: { tx: Buffer; signer: 
 
   return {
     amount: Number(amount),
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    blockhash: transaction.recentBlockhash!.toString(),
+    blockhash: transaction.recentBlockhash.toString(),
     destination,
     feePayer,
     source,

--- a/libs/solana/src/lib/helpers/serialize-create-account-transaction.ts
+++ b/libs/solana/src/lib/helpers/serialize-create-account-transaction.ts
@@ -1,19 +1,21 @@
 import { Keypair } from '@kin-kinetic/keypair'
-import { createAssociatedTokenAccountInstruction, getAssociatedTokenAddress } from '@solana/spl-token'
-import { Transaction, TransactionInstruction } from '@solana/web3.js'
 import { TransactionType } from '@kin-tools/kin-memo'
 import { generateKinMemoInstruction } from '@kin-tools/kin-transaction'
+import { createAssociatedTokenAccountInstruction, getAssociatedTokenAddress } from '@solana/spl-token'
+import { Transaction, TransactionInstruction } from '@solana/web3.js'
 import { PublicKeyString } from '../interfaces'
 import { getPublicKey } from './get-public-key'
 
 export async function serializeCreateAccountTransaction({
   appIndex,
+  lastValidBlockHeight,
   latestBlockhash,
   mintFeePayer,
   mintPublicKey,
   owner,
 }: {
   appIndex: number
+  lastValidBlockHeight: number
   latestBlockhash: string
   mintFeePayer: PublicKeyString
   mintPublicKey: PublicKeyString
@@ -39,13 +41,14 @@ export async function serializeCreateAccountTransaction({
   ]
 
   const transaction = new Transaction({
+    blockhash: latestBlockhash,
     feePayer: feePayerKey,
-    recentBlockhash: latestBlockhash,
+    lastValidBlockHeight,
     signatures: [{ publicKey: owner.solana.publicKey, signature: null }],
   }).add(...instructions)
 
   // Sign and Serialize Transaction
-  transaction.partialSign(...[owner.solana])
+  transaction.partialSign(owner.solana)
 
   return transaction.serialize({ requireAllSignatures: false, verifySignatures: false })
 }

--- a/libs/solana/src/lib/helpers/serialize-make-transfer-batch-transactions.ts
+++ b/libs/solana/src/lib/helpers/serialize-make-transfer-batch-transactions.ts
@@ -10,6 +10,7 @@ import { getPublicKey } from './get-public-key'
 export async function serializeMakeTransferBatchTransactions({
   appIndex,
   destinations,
+  lastValidBlockHeight,
   latestBlockhash,
   mintDecimals,
   mintFeePayer,
@@ -19,6 +20,7 @@ export async function serializeMakeTransferBatchTransactions({
 }: {
   appIndex: number
   destinations: Destination[]
+  lastValidBlockHeight: number
   latestBlockhash: string
   mintDecimals: number
   mintFeePayer: PublicKeyString
@@ -54,13 +56,14 @@ export async function serializeMakeTransferBatchTransactions({
   ]
 
   const transaction = new Transaction({
+    blockhash: latestBlockhash,
     feePayer: feePayerKey,
-    recentBlockhash: latestBlockhash,
+    lastValidBlockHeight,
     signatures: [{ publicKey: owner.solana.publicKey, signature: null }],
   }).add(...instructions)
 
   // Sign and Serialize Transaction
-  transaction.partialSign(...[owner.solana])
+  transaction.partialSign(owner.solana)
 
   return transaction.serialize({ requireAllSignatures: false, verifySignatures: false })
 }

--- a/libs/solana/src/lib/helpers/serialize-make-transfer-transaction.ts
+++ b/libs/solana/src/lib/helpers/serialize-make-transfer-transaction.ts
@@ -11,6 +11,7 @@ export async function serializeMakeTransferTransaction({
   amount,
   appIndex,
   destination,
+  lastValidBlockHeight,
   latestBlockhash,
   mintDecimals,
   mintFeePayer,
@@ -21,6 +22,7 @@ export async function serializeMakeTransferTransaction({
   amount: string
   appIndex: number
   destination: PublicKeyString
+  lastValidBlockHeight: number
   latestBlockhash: string
   mintDecimals: number
   mintFeePayer: PublicKeyString
@@ -57,13 +59,14 @@ export async function serializeMakeTransferTransaction({
   ]
 
   const transaction = new Transaction({
+    blockhash: latestBlockhash,
     feePayer: feePayerKey,
-    recentBlockhash: latestBlockhash,
+    lastValidBlockHeight,
     signatures: [{ publicKey: owner.solana.publicKey, signature: null }],
   }).add(...instructions)
 
   // Sign and Serialize Transaction
-  transaction.partialSign(...[owner.solana])
+  transaction.partialSign(owner.solana)
 
   return transaction.serialize({ requireAllSignatures: false, verifySignatures: false })
 }


### PR DESCRIPTION
We were using the [deprecated](https://github.com/solana-labs/solana/blob/627d91fb20272afa5ce790fbec01b40a29fb9852/web3.js/src/transaction.ts#L134) way to create the `Transaction`, we are now using the correct way. 

~~This also means we don't need to provide `lastValidBlockHeight` as a separate property on the `makeTransfer` endpoint. Instead, we can read it by parsing the incoming transaction.~~

Edit: it turns out `lastValidBlockHeight` is not serialized on the `Transaction` so we will still send it as a separate property to the `makeTransfer` endpoint.