### PR TITLE
feat: set account close authority to fee payer

### DIFF
--- a/libs/solana/src/lib/helpers/generate-create-account-transaction.ts
+++ b/libs/solana/src/lib/helpers/generate-create-account-transaction.ts
@@ -1,6 +1,11 @@
 import { TransactionType } from '@kin-tools/kin-memo'
 import { generateKinMemoInstruction } from '@kin-tools/kin-transaction'
-import { createAssociatedTokenAccountInstruction, getAssociatedTokenAddress } from '@solana/spl-token'
+import {
+  AuthorityType,
+  createAssociatedTokenAccountInstruction,
+  createSetAuthorityInstruction,
+  getAssociatedTokenAddress,
+} from '@solana/spl-token'
 import { Transaction, TransactionInstruction } from '@solana/web3.js'
 import { GenerateCreateAccountTransactionOptions } from '../interfaces'
 import { getPublicKey } from './get-public-key'
@@ -30,6 +35,7 @@ export async function generateCreateAccountTransaction({
   const instructions: TransactionInstruction[] = [
     appIndexMemoInstruction,
     createAssociatedTokenAccountInstruction(feePayerKey, associatedTokenAccount, signer.publicKey, mintKey),
+    createSetAuthorityInstruction(associatedTokenAccount, signer.publicKey, AuthorityType.CloseAccount, feePayerKey),
   ]
 
   const transaction = new Transaction({


### PR DESCRIPTION
With this instruction, we set the `closeAuthority` to the fee payer, which allows the accounts to be closed by them when they have a `0` balance. Needed in order for #308 #326 to work.

https://explorer.solana.com/tx/5VW2ivAEqrWCyJDwiceb6XN28GNRYAZF4fMJ7Xb9AnfZQpXp9n9hSQ7nteLnUMLMYNkm2JqCfPSChSvVzPVvWyDP?cluster=devnet

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/36491/177772482-61456ecd-831f-4647-80f2-b32c995e98d6.png">

I created a follow-up #339 to make sure we do the same when an account gets created on `senderCreate`.
