### PR TITLE
feat: configure GraphQL CORS settings

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -13,7 +13,7 @@ async function bootstrap() {
   await OpenTelementrySdk.start(config.metricsEnabled)
   app.setGlobalPrefix(config.prefix)
   app.useGlobalPipes(new ValidationPipe({ transform: true }))
-  app.enableCors({ origin: config.corsOrigins })
+  app.enableCors(config.cors)
   app.use(redirectSSL.create({ enabled: config.isProduction }))
   config.configureSwagger(app)
   app.use(cookieParser())

--- a/libs/api/config/data-access/src/lib/api-config-data-access.service.ts
+++ b/libs/api/config/data-access/src/lib/api-config-data-access.service.ts
@@ -1,9 +1,11 @@
 import { createMintKin, createMintSol, createMintUsdc } from '@kin-kinetic/api/cluster/util'
+import { ApolloDriverConfig } from '@nestjs/apollo'
 import { INestApplication, Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 import { ClusterStatus, ClusterType, Prisma } from '@prisma/client'
 import * as fs from 'fs'
+import { join } from 'path'
 import { ProvisionedApp } from './entities/provisioned-app.entity'
 import { getProvisionedApps } from './helpers/get-provisioned-apps'
 
@@ -64,6 +66,13 @@ export class ApiConfigDataAccessService {
     return this.config.get('admin.password')
   }
 
+  get cors() {
+    return {
+      credentials: true,
+      origin: this.corsOrigins,
+    }
+  }
+
   get corsOrigins(): string[] {
     return this.config.get('cors.origin')
   }
@@ -86,6 +95,16 @@ export class ApiConfigDataAccessService {
 
   get environment() {
     return this.config.get('environment')
+  }
+
+  get graphqlConfig(): ApolloDriverConfig {
+    return {
+      autoSchemaFile: join(process.cwd(), 'api-schema.graphql'),
+      context: ({ req, res }) => ({ req, res }),
+      cors: this.cors,
+      playground: { settings: { 'request.credentials': 'include' } },
+      sortSchema: true,
+    }
   }
 
   get isDevelopment(): boolean {

--- a/libs/api/core/feature/src/lib/api-core-feature.module.ts
+++ b/libs/api/core/feature/src/lib/api-core-feature.module.ts
@@ -15,7 +15,6 @@ import { GraphQLModule } from '@nestjs/graphql'
 import { ScheduleModule } from '@nestjs/schedule'
 import { ServeStaticModule } from '@nestjs/serve-static'
 import { OpenTelemetryModule } from 'nestjs-otel'
-import { join } from 'path'
 import { ApiCoreFeatureController } from './api-core-feature.controller'
 import { ApiCoreFeatureResolver } from './api-core-feature.resolver'
 import { serveStaticFactory } from './serve-static.factory'
@@ -24,16 +23,11 @@ import { serveStaticFactory } from './serve-static.factory'
   controllers: [ApiCoreFeatureController],
   providers: [ApiCoreFeatureResolver],
   imports: [
-    GraphQLModule.forRoot<ApolloDriverConfig>({
-      autoSchemaFile: join(process.cwd(), 'api-schema.graphql'),
-      context: ({ req, res }) => ({ req, res }),
+    GraphQLModule.forRootAsync<ApolloDriverConfig>({
       driver: ApolloDriver,
-      playground: {
-        settings: {
-          'request.credentials': 'include',
-        },
-      },
-      sortSchema: true,
+      imports: [ApiConfigDataAccessModule],
+      inject: [ApiConfigDataAccessService],
+      useFactory: (cfg: ApiConfigDataAccessService) => cfg.graphqlConfig,
     }),
     ServeStaticModule.forRootAsync({ useFactory: serveStaticFactory() }),
     ApiAccountFeatureModule,


### PR DESCRIPTION
There were issues connecting the Kinetic Manager to the Devnet endpoint because of CORS configuration.

This PR fixes that.