### PR TITLE
feat: add env var to enable Prometheus port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ COOKIE_DOMAINS="localhost,local.kinetic.kin.org,pages.dev"
 #COOKIE_NAME="__session"
 CORS_ORIGINS=http://localhost:4200
 #METRICS_ENABLED=true
+#METRICS_ENDPOINT_ENABLED=true
 #METRICS_PORT=9001
 DATABASE_URL="postgresql://prisma:prisma@localhost:5432/prisma?schema=kinetic"
 JWT_SECRET="KineticJwtSecret!"

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ COOKIE_DOMAINS="localhost,local.kinetic.kin.org,pages.dev"
 #COOKIE_NAME="__session"
 CORS_ORIGINS=http://localhost:4200
 #METRICS_ENABLED=true
+#METRICS_PORT=9001
 DATABASE_URL="postgresql://prisma:prisma@localhost:5432/prisma?schema=kinetic"
 JWT_SECRET="KineticJwtSecret!"
 #DEFAULT_MINT_AIRDROP_AMOUNT=1000

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,5 +1,5 @@
 import { ApiConfigDataAccessService } from '@kin-kinetic/api/config/data-access'
-import { OpenTelementrySdk } from '@kin-kinetic/api/core/util'
+import { OpenTelemetrySdk } from '@kin-kinetic/api/core/util'
 import { Logger, ValidationPipe } from '@nestjs/common'
 import { NestFactory } from '@nestjs/core'
 import { exec } from 'child_process'
@@ -10,7 +10,7 @@ import { AppModule } from './app/app.module'
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
   const config = app.get(ApiConfigDataAccessService)
-  await OpenTelementrySdk.start(config.metricsEnabled)
+  await OpenTelemetrySdk.start(config.metricsConfig)
   app.setGlobalPrefix(config.prefix)
   app.useGlobalPipes(new ValidationPipe({ transform: true }))
   app.enableCors(config.cors)

--- a/libs/api/config/data-access/src/lib/api-config-data-access.service.ts
+++ b/libs/api/config/data-access/src/lib/api-config-data-access.service.ts
@@ -148,6 +148,10 @@ export class ApiConfigDataAccessService {
     return this.config.get('metrics.enabled')
   }
 
+  get metricsEndpointEnabled(): boolean {
+    return this.config.get('metrics.endpointEnabled')
+  }
+
   get metricsPort(): number {
     return this.config.get('metrics.port')
   }

--- a/libs/api/config/data-access/src/lib/api-config-data-access.service.ts
+++ b/libs/api/config/data-access/src/lib/api-config-data-access.service.ts
@@ -137,8 +137,19 @@ export class ApiConfigDataAccessService {
     return this.environment === 'development'
   }
 
+  get metricsConfig(): { enabled: boolean; port: number } {
+    return {
+      enabled: this.metricsEnabled,
+      port: this.metricsPort,
+    }
+  }
+
   get metricsEnabled(): boolean {
-    return this.config.get('metricsEnabled')
+    return this.config.get('metrics.enabled')
+  }
+
+  get metricsPort(): number {
+    return this.config.get('metrics.port')
   }
 
   get isProduction(): boolean {

--- a/libs/api/config/feature/src/lib/config/configuration.ts
+++ b/libs/api/config/feature/src/lib/config/configuration.ts
@@ -33,7 +33,10 @@ export default () => ({
   defaultMintAirdropAmount: process.env.DEFAULT_MINT_AIRDROP_AMOUNT,
   defaultMintAirdropMax: process.env.DEFAULT_MINT_AIRDROP_MAX,
   host: process.env.HOST,
-  metricsEnabled: process.env.METRICS_ENABLED?.toLowerCase() !== 'false',
+  metrics: {
+    enabled: process.env.METRICS_ENABLED?.toLowerCase() !== 'false',
+    port: parseInt(process.env.METRICS_PORT, 10),
+  },
   port: parseInt(process.env.PORT, 10),
   solanaDevnetRpcEndpoint: process.env.SOLANA_DEVNET_RPC_ENDPOINT,
   solanaMainnetRpcEndpoint: process.env.SOLANA_MAINNET_RPC_ENDPOINT,

--- a/libs/api/config/feature/src/lib/config/configuration.ts
+++ b/libs/api/config/feature/src/lib/config/configuration.ts
@@ -35,6 +35,7 @@ export default () => ({
   host: process.env.HOST,
   metrics: {
     enabled: process.env.METRICS_ENABLED?.toLowerCase() !== 'false',
+    endpointEnabled: process.env.METRICS_ENDPOINT_ENABLED?.toLowerCase() !== 'false',
     port: parseInt(process.env.METRICS_PORT, 10),
   },
   port: parseInt(process.env.PORT, 10),

--- a/libs/api/config/feature/src/lib/config/validation-schema.ts
+++ b/libs/api/config/feature/src/lib/config/validation-schema.ts
@@ -15,6 +15,7 @@ export const validationSchema = Joi.object({
   HOST: Joi.string().default('127.0.0.1'),
   JWT_SECRET: Joi.string().required(),
   METRICS_ENABLED: Joi.boolean().default(false),
+  METRICS_PORT: Joi.number().default(0),
   NODE_ENV: Joi.string().valid('development', 'production', 'test').default('development'),
   PORT: Joi.number().default(3000),
   SOLANA_DEVNET_RPC_ENDPOINT: Joi.string().default('devnet'),

--- a/libs/api/config/feature/src/lib/config/validation-schema.ts
+++ b/libs/api/config/feature/src/lib/config/validation-schema.ts
@@ -15,6 +15,7 @@ export const validationSchema = Joi.object({
   HOST: Joi.string().default('127.0.0.1'),
   JWT_SECRET: Joi.string().required(),
   METRICS_ENABLED: Joi.boolean().default(false),
+  METRICS_ENDPOINT_ENABLED: Joi.boolean().default(false),
   METRICS_PORT: Joi.number().default(0),
   NODE_ENV: Joi.string().valid('development', 'production', 'test').default('development'),
   PORT: Joi.number().default(3000),

--- a/libs/api/core/feature/src/lib/api-core-feature.controller.ts
+++ b/libs/api/core/feature/src/lib/api-core-feature.controller.ts
@@ -1,5 +1,5 @@
 import { ApiCoreDataAccessService } from '@kin-kinetic/api/core/data-access'
-import { OpenTelementrySdk } from '@kin-kinetic/api/core/util'
+import { OpenTelemetrySdk } from '@kin-kinetic/api/core/util'
 import { Controller, Get, Response } from '@nestjs/common'
 import { ApiExcludeEndpoint } from '@nestjs/swagger'
 
@@ -10,7 +10,7 @@ export class ApiCoreFeatureController {
   @Get('metrics')
   @ApiExcludeEndpoint()
   metrics(@Response() response) {
-    return OpenTelementrySdk.getMetrics(response)
+    return OpenTelemetrySdk.getMetrics(response)
   }
 
   @Get('uptime')

--- a/libs/api/core/feature/src/lib/api-core-feature.controller.ts
+++ b/libs/api/core/feature/src/lib/api-core-feature.controller.ts
@@ -1,6 +1,6 @@
 import { ApiCoreDataAccessService } from '@kin-kinetic/api/core/data-access'
 import { OpenTelemetrySdk } from '@kin-kinetic/api/core/util'
-import { Controller, Get, Response } from '@nestjs/common'
+import { Controller, Get, NotFoundException, Response } from '@nestjs/common'
 import { ApiExcludeEndpoint } from '@nestjs/swagger'
 
 @Controller()
@@ -10,6 +10,9 @@ export class ApiCoreFeatureController {
   @Get('metrics')
   @ApiExcludeEndpoint()
   metrics(@Response() response) {
+    if (!this.service.config.metricsEndpointEnabled) {
+      throw new NotFoundException()
+    }
     return OpenTelemetrySdk.getMetrics(response)
   }
 

--- a/libs/api/core/util/src/lib/open-telemetry-sdk.ts
+++ b/libs/api/core/util/src/lib/open-telemetry-sdk.ts
@@ -3,20 +3,24 @@ import { PrometheusExporter } from '@opentelemetry/exporter-prometheus'
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { ServerResponse } from 'http'
 
-export class OpenTelementrySdk {
+export class OpenTelemetrySdk {
   static sdk: NodeSDK
   private static metricExporter: PrometheusExporter
 
-  static start(metricsEnabled: boolean) {
-    if (!metricsEnabled) {
+  static start({ enabled, port }: { enabled: boolean; port: number }) {
+    if (!enabled) {
       Logger.verbose(`Metrics are disabled, set METRICS_ENABLED=true to enable them`, 'OpenTelementrySdk')
       return true
     }
-    Logger.verbose(`Metrics are enabled`, 'OpenTelementrySdk')
+    Logger.verbose(`Metrics are enabled`, 'OpenTelemetrySdk')
+    if (port > 0) {
+      Logger.verbose(`Metrics listening on port ${port}`, 'OpenTelemetrySdk')
+    }
 
     this.metricExporter = new PrometheusExporter({
       prefix: 'kinetic',
-      preventServerStart: true,
+      preventServerStart: !port,
+      port,
     })
 
     this.sdk = new NodeSDK({


### PR DESCRIPTION
This feature is needed so we can toggle how the Prometheus metrics are exposed:

- `METRICS_PORT=9000` opens a port with a `/metrics` endpoint
- `METRICS_ENDPOINT_ENABLED=true` enabled the `/api/metrics` endpoint on the API