### PR TITLE
fix: make cors origin work with '*'

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -23,7 +23,13 @@ async function bootstrap() {
     Logger.log(`🚀 Admin API is running on http://localhost:${config.port}/graphql.`)
     Logger.log(`🔋 API_URL: ${config.apiUrl}`)
     Logger.log(`🔋 COOKIE_DOMAINS: ${config.cookieDomains.join(', ')}`)
-    Logger.log(`🔋 CORS: ${config?.corsOrigins ? `enabled for: ${config?.corsOrigins?.join(', ')}` : 'disabled'}`)
+    Logger.log(
+      `🔋 CORS: ${
+        config?.corsOrigins
+          ? `enabled for: ${Array.isArray(config?.corsOrigins) ? config?.corsOrigins?.join(', ') : config?.corsOrigins}`
+          : 'disabled'
+      }`,
+    )
 
     if (config.isDevelopment) {
       exec('prettier --write ./api-schema.graphql ./api-swagger.json', { cwd: process.cwd() })


### PR DESCRIPTION
Fixes this error when setting `CORS_ORIGINS` to `*`.

```
2022-09-03T16:10:51.720125+00:00 app[web.1]: [Nest] 25  - 09/03/2022, 4:10:51 PM   ERROR TypeError: _a.join is not a function
2022-09-03T16:10:51.721646+00:00 app[web.1]: TypeError: _a.join is not a function
2022-09-03T16:10:51.721647+00:00 app[web.1]: at /workspace/dist/apps/api/main.js:1:309887
2022-09-03T16:10:51.721647+00:00 app[web.1]: at Generator.next (<anonymous>)
2022-09-03T16:10:51.721648+00:00 app[web.1]: at fulfilled (/workspace/node_modules/tslib/tslib.js:115:62)
2022-09-03T16:10:51.721648+00:00 app[web.1]: at processTicksAndRejections (node:internal/process/task_queues:96:5)
```