### PR TITLE
fix: add Buffer polyfill to Keypair class

### DIFF
--- a/libs/keypair/src/lib/keypair-polyfills.ts
+++ b/libs/keypair/src/lib/keypair-polyfills.ts
@@ -1,3 +1,10 @@
+// Polyfill the browser, prevents the error "Uncaught ReferenceError: Buffer is not defined"
+if (typeof window !== 'undefined' && typeof window.global === 'undefined' && typeof Buffer === 'undefined') {
+  window['global'] = window
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  global.Buffer = require('buffer').Buffer
+}
+
 if (typeof TextEncoder === 'undefined' || typeof window === 'undefined') {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   global.TextEncoder = require('util').TextEncoder


### PR DESCRIPTION
This polyfill is needed in both the `keypair` and `sdk` packages, so the `keypair` package can be used standalone.