### PR TITLE
fix: disable optimization for API as a workaround for GraphQL schema error

### DIFF
--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -16,7 +16,7 @@
       },
       "configurations": {
         "production": {
-          "optimization": true,
+          "optimization": false,
           "extractLicenses": true,
           "inspect": false,
           "fileReplacements": [


### PR DESCRIPTION
A recent update broke running the API in Production mode, with the following error:

```
Error: Schema must contain uniquely named types but contains multiple types named "o".
    at new GraphQLSchema (/Users/beeman/kin/kin-labs/kinetic/node_modules/graphql/type/schema.js:219:15)
    at GraphQLSchemaFactory.create (/Users/beeman/kin/kin-labs/kinetic/node_modules/@nestjs/graphql/dist/schema-builder/graphql-schema.factory.js:40:24)
    at GraphQLSchemaBuilder.generateSchema (/Users/beeman/kin/kin-labs/kinetic/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:35:52)
    at GraphQLSchemaBuilder.build (/Users/beeman/kin/kin-labs/kinetic/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:22:31)
    at GraphQLFactory.mergeWithSchema (/Users/beeman/kin/kin-labs/kinetic/node_modules/@nestjs/graphql/dist/graphql.factory.js:29:69)
    at ApolloDriver.start (/Users/beeman/kin/kin-labs/kinetic/node_modules/@nestjs/apollo/dist/drivers/apollo.driver.js:19:51)
    at GraphQLModule.onModuleInit (/Users/beeman/kin/kin-labs/kinetic/node_modules/@nestjs/graphql/dist/graphql.module.js:105:36)
    at async callModuleInitHook (/Users/beeman/kin/kin-labs/kinetic/node_modules/@nestjs/core/hooks/on-module-init.hook.js:51:9)
    at async NestApplication.callInitHook (/Users/beeman/kin/kin-labs/kinetic/node_modules/@nestjs/core/nest-application-context.js:178:13)
    at async NestApplication.init (/Users/beeman/kin/kin-labs/kinetic/node_modules/@nestjs/core/nest-application.js:96:9)
``` 

After looking at this for a few hours I found a workaround which is disable optimization of the build. 

Considering this is on the API, having a slightly smaller bundle is probably not an issue.  