### PR TITLE
feat: allow setting the 'secure' property on cookies using env vars

### DIFF
--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -1,6 +1,7 @@
 name: build-publish-docker
 
 on:
+  pull_request:
   push:
     branches:
       - dev
@@ -36,7 +37,6 @@ jobs:
 
       - name: Build and push Docker (dev)
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        if: github.ref == 'refs/heads/dev'
         with:
           context: .
           push: true

--- a/libs/api/config/data-access/src/lib/api-config-data-access.service.ts
+++ b/libs/api/config/data-access/src/lib/api-config-data-access.service.ts
@@ -88,6 +88,10 @@ export class ApiConfigDataAccessService {
     return this.config.get('cookie.name')
   }
 
+  get cookieSecure(): boolean {
+    return this.config.get('cookie.secure')
+  }
+
   cookieOptions(hostname: string): CookieOptions {
     const found = this.cookieDomains.find((domain) => hostname.endsWith(domain))
     if (!found) {
@@ -95,7 +99,7 @@ export class ApiConfigDataAccessService {
     }
     return {
       httpOnly: true,
-      secure: true,
+      secure: this.cookieSecure,
       domain: found || this.cookieDomains[0],
       sameSite: this.cookieDomains?.length > 1 ? 'none' : 'strict',
     }

--- a/libs/api/config/feature/src/lib/config/configuration.ts
+++ b/libs/api/config/feature/src/lib/config/configuration.ts
@@ -32,6 +32,7 @@ export default () => ({
   cookie: {
     domains,
     name: process.env.COOKIE_NAME,
+    secure: process.env.COOKIE_SECURE?.toLowerCase() !== 'false',
   },
   discord: {
     clientId: process.env.DISCORD_CLIENT_ID,

--- a/libs/api/config/feature/src/lib/config/validation-schema.ts
+++ b/libs/api/config/feature/src/lib/config/validation-schema.ts
@@ -7,6 +7,7 @@ export const validationSchema = Joi.object({
   AUTH_USERS: Joi.string().default(''),
   COOKIE_DOMAINS: Joi.string().required().error(new Error(`COOKIE_DOMAINS is required.`)),
   COOKIE_NAME: Joi.string().default('__session'),
+  COOKIE_SECURE: Joi.boolean().default('true'),
   DATABASE_URL: Joi.string().required(),
   GITHUB_ENABLED: Joi.boolean().default('false'),
   GOOGLE_ENABLED: Joi.boolean().default('false'),


### PR DESCRIPTION
When running Kinetic on a domain like `http://local.kinetit.host`, the secure setting should not be set.

Setting `COOKIE_SECURE=false` should make this work.

<img width="844" alt="image" src="https://user-images.githubusercontent.com/36491/197419853-aadb9e93-0e52-494f-a784-cc14e88db941.png">
