### PR TITLE
Fix behavior with updating Cluster endpoints

### DIFF
--- a/libs/api/config/data-access/src/lib/api-config-data-access.service.ts
+++ b/libs/api/config/data-access/src/lib/api-config-data-access.service.ts
@@ -210,6 +210,7 @@ export class ApiConfigDataAccessService {
   get solanaDevnetEnabled(): boolean {
     return this.config.get('solana.devnet.enabled')
   }
+
   get solanaDevnetRpcEndpoint() {
     return this.config.get('solana.devnet.rpcEndpoint')
   }

--- a/libs/api/core/data-access/src/lib/api-core-data-access.service.ts
+++ b/libs/api/core/data-access/src/lib/api-core-data-access.service.ts
@@ -217,6 +217,7 @@ export class ApiCoreDataAccessService extends PrismaClient implements OnModuleIn
           logger: getVerboseLogger(`@kin-kinetic/solana:${appKey}`),
         }),
       )
+      this.logger.log(`Created new connection for ${appKey}`)
     }
     return this.connections.get(appKey)
   }

--- a/libs/web/admin/feature/src/lib/cluster/web-admin-feature-cluster-detail.tsx
+++ b/libs/web/admin/feature/src/lib/cluster/web-admin-feature-cluster-detail.tsx
@@ -22,15 +22,15 @@ export function WebAdminFeatureClusterDetail() {
   }
 
   const tabs = [
-    { label: 'Mints', path: 'mints' },
     { label: 'Settings', path: 'settings' },
+    { label: 'Mints', path: 'mints' },
   ]
 
   return (
     <WebUiPage title={data.item.name || ''} actionLeft={<WebUiPageBackButton />}>
       <WebAdminUiTabs tabs={tabs}>
         <Routes>
-          <Route index element={<Navigate to="mints" replace />} />
+          <Route index element={<Navigate to="settings" replace />} />
           <Route
             path="mints"
             element={<WebAdminFeatureClusterMintsTab cluster={data?.item} mints={data?.item.mints} />}


### PR DESCRIPTION
Fixes #467 

@RamirezAlex in this PR we change how Clusters/Mints are provisioned, making it so that they are only created but never update. The result of this is that it will make the local development workflow a bit different. If we want to change a cluster endpoint while our local setup, we will either have to use the admin and configure it there or use ENV Vars and reset the database.