### PR TITLE
fix: allow setting cookies over http connections

### DIFF
--- a/libs/api/config/data-access/src/lib/api-config-data-access.service.ts
+++ b/libs/api/config/data-access/src/lib/api-config-data-access.service.ts
@@ -80,11 +80,12 @@ export class ApiConfigDataAccessService {
     if (!found) {
       this.logger.warn(`Not configured to set cookies for ${hostname}`)
     }
+    const isSecure = this.apiUrl.startsWith('https')
     return {
       httpOnly: true,
-      secure: true,
+      secure: isSecure,
       domain: found || this.cookieDomains[0],
-      sameSite: this.cookieDomains?.length > 1 ? 'none' : 'strict',
+      sameSite: isSecure ? 'none' : 'strict',
     }
   }
 


### PR DESCRIPTION
Several people reported issues with logging in, it turns out the cookie was not set correctly. See the error in the screenshot.

![image](https://user-images.githubusercontent.com/36491/201490681-f9f3c2c7-f873-405f-94ae-3f019f3430e0.png)

This PR fixes that.