### PR TITLE
feat: infer WEB_URL from API_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,4 +73,6 @@ SOLANA_DEVNET_MINT_KIN_AIRDROP_SECRET_KEY=[24,20,238,188,26,234,120,209,88,63,17
 #SOLANA_MAINNET_RPC_ENDPOINT=mainnet
 SOLANA_MAINNET_ENABLED=false
 # The URL of the Web UI, used to redirect to the Web UI after login.
+# In a typical deployment, this is the same as the API_URL with the '/api' suffix removed (the default).
+# This means you will probably only need to set this if you are running a local development setup.
 WEB_URL=http://localhost:4200

--- a/libs/api/config/feature/src/lib/config/configuration.ts
+++ b/libs/api/config/feature/src/lib/config/configuration.ts
@@ -1,5 +1,10 @@
 import { NAME, VERSION } from '@kin-kinetic/api/core/data-access'
 
+// Remove trailing slashes from the URLs to avoid double slashes
+const API_URL = process.env.API_URL?.replace(/\/$/, '')
+// Infer the WEB URL from the API_URL if it's not set
+const WEB_URL = process.env.WEB_URL?.replace(/\/$/, '') ?? API_URL?.replace('/api', '')
+
 // Get the origins from the ENV
 const origins: string[] = process.env.CORS_ORIGINS?.includes(',')
   ? process.env.CORS_ORIGINS?.split(',')
@@ -18,7 +23,7 @@ export default () => ({
       level: process.env.LOG_LEVEL,
     },
     name: NAME,
-    url: process.env.API_URL,
+    url: API_URL,
     version: VERSION,
   },
   auth: {
@@ -74,6 +79,6 @@ export default () => ({
     },
   },
   web: {
-    url: process.env.WEB_URL,
+    url: WEB_URL,
   },
 })

--- a/libs/api/config/feature/src/lib/config/validation-schema.ts
+++ b/libs/api/config/feature/src/lib/config/validation-schema.ts
@@ -31,5 +31,5 @@ export const validationSchema = Joi.object({
   SOLANA_MAINNET_ENABLED: Joi.boolean().default(false),
   SOLANA_MAINNET_MINT_KIN: Joi.string().default('*kinXdEcpDQeHPEuQnqmUgtYykqKGVFq6CeVX5iAHJq6,5,Kin'),
   SOLANA_MAINNET_RPC_ENDPOINT: Joi.string().default('mainnet-beta'),
-  WEB_URL: Joi.string().required().error(new Error(`WEB_URL is required.`)),
+  WEB_URL: Joi.string(),
 })


### PR DESCRIPTION
The `WEB_URL` property only needs to be set on a development setup, or when running the web UI separate from the API. On a typical production setup it will be the same as the `API_URL` with the `/api` suffix stripped off.