### PR TITLE
feat: infer COOKIE_DOMAINS default value from API_URL

### DIFF
--- a/libs/api/config/feature/src/lib/config/configuration.ts
+++ b/libs/api/config/feature/src/lib/config/configuration.ts
@@ -5,15 +5,15 @@ const API_URL = process.env.API_URL?.replace(/\/$/, '')
 // Infer the WEB URL from the API_URL if it's not set
 const WEB_URL = process.env.WEB_URL?.replace(/\/$/, '') ?? API_URL?.replace('/api', '')
 
-// Get the origins from the ENV
-const origins: string[] = process.env.CORS_ORIGINS?.includes(',')
-  ? process.env.CORS_ORIGINS?.split(',')
-  : [process.env.CORS_ORIGINS]
+const domains: string[] = getCookieDomains()
 
-// Get the cookie domains from the ENV
-const domains: string[] = process.env.COOKIE_DOMAINS?.includes(',')
-  ? process.env.COOKIE_DOMAINS?.split(',')
-  : [process.env.COOKIE_DOMAINS]
+// Infer the cookie domain from the API_URL if it's not set
+if (!domains.length) {
+  const { hostname } = new URL(API_URL)
+  domains.push(hostname)
+}
+
+const origins: string[] = getCorsOrigins()
 
 export default () => ({
   api: {
@@ -82,3 +82,18 @@ export default () => ({
     url: WEB_URL,
   },
 })
+
+// Get the cookie domains from the ENV
+function getCookieDomains() {
+  return getFromEnvironment('COOKIE_DOMAINS').filter(Boolean)
+}
+
+// Get the origins from the ENV
+function getCorsOrigins() {
+  return getFromEnvironment('CORS_ORIGINS').filter(Boolean)
+}
+
+// Get the values from the ENV
+function getFromEnvironment(key: string) {
+  return process.env[key]?.includes(',') ? process.env[key]?.split(',') : [process.env[key]]
+}

--- a/libs/api/config/feature/src/lib/config/validation-schema.ts
+++ b/libs/api/config/feature/src/lib/config/validation-schema.ts
@@ -4,7 +4,7 @@ export const validationSchema = Joi.object({
   API_URL: Joi.string().required().error(new Error(`API_URL is required.`)),
   AUTH_PASSWORD_ENABLED: Joi.boolean().default('false'),
   AUTH_USERS: Joi.string().default(''),
-  COOKIE_DOMAINS: Joi.string().required().error(new Error(`COOKIE_DOMAINS is required.`)),
+  COOKIE_DOMAINS: Joi.string(),
   COOKIE_NAME: Joi.string().default('__session'),
   CORS_BYPASS: Joi.boolean().default('false'),
   DATABASE_URL: Joi.string().required(),


### PR DESCRIPTION
With this patch, the `COOKIE_DOMAINS` property becomes optional and the default value will be set to the `hostname` part of the `API_URL` property, which should be the right value for most typical setups.