### PR TITLE
feat: infer bypassing CORS from lack of CORS_ORIGINS values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# The URL of the API server
+# The URL of the API server (required)
 API_URL=http://localhost:3000/api
 # Enable or disable authentication with username and password.
 # This is recommended to be disabled in production and use an external provider.
@@ -14,11 +14,10 @@ AUTH_USERS="alice|Kinetic@alice1|Admin|alice@email.com|http://avatars.dicebear.c
 APP_1_FEE_PAYER_BYTE_ARRAY=[24,20,238,188,26,234,120,209,88,63,170,46,66,98,21,113,194,120,143,228,231,37,91,0,242,32,180,99,243,179,57,144,11,233,235,235,203,20,105,33,47,140,152,253,12,148,72,175,141,253,242,110,225,110,21,211,118,87,111,206,208,166,190,78]
 APP_1_NAME="App 1"
 #APP_1_LOGO_URL=""
-COOKIE_DOMAINS="localhost,local.kinetic.host,pages.dev"
+#COOKIE_DOMAINS="localhost,local.kinetic.host,pages.dev"
 #COOKIE_NAME="__session"
-# You can bypass CORS checks by setting this to true.
-CORS_BYPASS=true
 # If you want to configure CORS, define a comma-separated list of urls here.
+# If you don't provide any domains, CORS will be bypassed (default).
 #CORS_ORIGINS=http://localhost:4200
 #METRICS_ENABLED=true
 #METRICS_ENDPOINT_ENABLED=true
@@ -45,6 +44,7 @@ DATABASE_URL="postgresql://prisma:prisma@localhost:5432/prisma?schema=kinetic"
 #GOOGLE_CLIENT_ID=x
 #GOOGLE_CLIENT_SECRET=x
 #GOOGLE_ENABLED=false
+# Secret used to sign JWT tokens (required)
 JWT_SECRET="KineticJwtSecret!"
 # Configure the host where the API listens on.
 # Use 127.0.0.1 if you only want to allow connections from localhost.

--- a/.github/workflows/test-api-e2e.yml
+++ b/.github/workflows/test-api-e2e.yml
@@ -13,7 +13,6 @@ env:
   APP_1_NAME: 'App 1'
   AUTH_USERS: 'alice|Kinetic@alice1|Admin,bob|Kinetic@bob1'
   AUTH_PASSWORD_ENABLED: true
-  COOKIE_DOMAINS: 'localhost'
   COOKIE_NAME: '__session'
   DATABASE_URL: 'postgresql://prisma:prisma@localhost:5432/prisma?schema=kinetic'
   JWT_SECRET: 'KineticJwtSecret!'
@@ -25,7 +24,6 @@ env:
   SOLANA_DEVNET_RPC_ENDPOINT: 'http://localhost:8899'
   SOLANA_DEVNET_MINT_KIN: '*MoGaMuJnB3k8zXjBYBnHxHG47vWcW3nyb7bFYvdVzek,5,Kin'
   SOLANA_DEVNET_MINT_KIN_AIRDROP_SECRET_KEY: '[24,20,238,188,26,234,120,209,88,63,170,46,66,98,21,113,194,120,143,228,231,37,91,0,242,32,180,99,243,179,57,144,11,233,235,235,203,20,105,33,47,140,152,253,12,148,72,175,141,253,242,110,225,110,21,211,118,87,111,206,208,166,190,78]'
-  WEB_URL: 'http://localhost:3000'
 
 jobs:
   main:

--- a/.github/workflows/test-sdk-e2e.yml
+++ b/.github/workflows/test-sdk-e2e.yml
@@ -13,9 +13,7 @@ env:
   APP_1_NAME: 'App 1'
   AUTH_USERS: 'alice|Kinetic@alice1|Admin,bob|Kinetic@bob1'
   AUTH_PASSWORD_ENABLED: true
-  COOKIE_DOMAINS: 'localhost'
   COOKIE_NAME: '__session'
-  CORS_BYPASS: 'true'
   DATABASE_URL: 'postgresql://prisma:prisma@localhost:5432/prisma?schema=kinetic'
   JWT_SECRET: 'KineticJwtSecret!'
   NX_CLOUD_DISTRIBUTED_EXECUTION: false
@@ -25,7 +23,6 @@ env:
   SOLANA_LOCAL_MINT_USDC: '*USDzo281m7rjzeZyxevkzL1vr5Cibb9ek3ynyAjXjUM,2,USDC'
   SOLANA_LOCAL_MINT_USDC_AIRDROP_SECRET_KEY: '[24,20,238,188,26,234,120,209,88,63,170,46,66,98,21,113,194,120,143,228,231,37,91,0,242,32,180,99,243,179,57,144,11,233,235,235,203,20,105,33,47,140,152,253,12,148,72,175,141,253,242,110,225,110,21,211,118,87,111,206,208,166,190,78]'
   SOLANA_LOCAL_RPC_ENDPOINT: 'http://localhost:8899'
-  WEB_URL: 'http://localhost:3000'
 
 jobs:
   main:

--- a/.github/workflows/test-web-e2e.yml
+++ b/.github/workflows/test-web-e2e.yml
@@ -13,7 +13,6 @@ env:
   APP_1_NAME: 'App 1'
   AUTH_USERS: 'alice|Kinetic@alice1|Admin,bob|Kinetic@bob1'
   AUTH_PASSWORD_ENABLED: true
-  COOKIE_DOMAINS: 'localhost'
   COOKIE_NAME: '__session'
   DATABASE_URL: 'postgresql://prisma:prisma@localhost:5432/prisma?schema=kinetic'
   JWT_SECRET: 'KineticJwtSecret!'
@@ -21,7 +20,6 @@ env:
   SOLANA_DEVNET_RPC_ENDPOINT: 'http://localhost:8899'
   SOLANA_DEVNET_MINT_KIN: '*MoGaMuJnB3k8zXjBYBnHxHG47vWcW3nyb7bFYvdVzek,5,Kin'
   SOLANA_DEVNET_MINT_KIN_AIRDROP_SECRET_KEY: '[24,20,238,188,26,234,120,209,88,63,170,46,66,98,21,113,194,120,143,228,231,37,91,0,242,32,180,99,243,179,57,144,11,233,235,235,203,20,105,33,47,140,152,253,12,148,72,175,141,253,242,110,225,110,21,211,118,87,111,206,208,166,190,78]'
-  WEB_URL: 'http://localhost:3000'
 
 jobs:
   main:

--- a/libs/api/config/feature/src/lib/config/configuration.ts
+++ b/libs/api/config/feature/src/lib/config/configuration.ts
@@ -1,9 +1,9 @@
 import { NAME, VERSION } from '@kin-kinetic/api/core/data-access'
 
 // Remove trailing slashes from the URLs to avoid double slashes
-const API_URL = process.env.API_URL?.replace(/\/$/, '')
+const API_URL = getUrl('API_URL')
 // Infer the WEB URL from the API_URL if it's not set
-const WEB_URL = process.env.WEB_URL?.replace(/\/$/, '') ?? API_URL?.replace('/api', '')
+const WEB_URL = getUrl('WEB_URL') ?? API_URL?.replace('/api', '')
 
 const domains: string[] = getCookieDomains()
 
@@ -31,7 +31,7 @@ export default () => ({
     users: process.env.AUTH_USERS || '',
   },
   cors: {
-    bypass: process.env.CORS_BYPASS?.toLowerCase() !== 'false',
+    bypass: !origins.length,
     origins,
   },
   cookie: {
@@ -96,4 +96,8 @@ function getCorsOrigins() {
 // Get the values from the ENV
 function getFromEnvironment(key: string) {
   return process.env[key]?.includes(',') ? process.env[key]?.split(',') : [process.env[key]]
+}
+
+function getUrl(key: string) {
+  return process.env[key]?.replace(/\/$/, '')
 }

--- a/libs/api/config/feature/src/lib/config/validation-schema.ts
+++ b/libs/api/config/feature/src/lib/config/validation-schema.ts
@@ -4,9 +4,7 @@ export const validationSchema = Joi.object({
   API_URL: Joi.string().required().error(new Error(`API_URL is required.`)),
   AUTH_PASSWORD_ENABLED: Joi.boolean().default('false'),
   AUTH_USERS: Joi.string().default(''),
-  COOKIE_DOMAINS: Joi.string(),
   COOKIE_NAME: Joi.string().default('__session'),
-  CORS_BYPASS: Joi.boolean().default('false'),
   DATABASE_URL: Joi.string().required(),
   GITHUB_ENABLED: Joi.boolean().default('false'),
   GOOGLE_ENABLED: Joi.boolean().default('false'),
@@ -31,5 +29,4 @@ export const validationSchema = Joi.object({
   SOLANA_MAINNET_ENABLED: Joi.boolean().default(false),
   SOLANA_MAINNET_MINT_KIN: Joi.string().default('*kinXdEcpDQeHPEuQnqmUgtYykqKGVFq6CeVX5iAHJq6,5,Kin'),
   SOLANA_MAINNET_RPC_ENDPOINT: Joi.string().default('mainnet-beta'),
-  WEB_URL: Joi.string(),
 })


### PR DESCRIPTION
With this patch, we no longer need to set `CORS_BYPASS`. Instead, we will assume that CORS can be bypassed when no explicit `CORS_ORIGINS` are set. All this to make configuration simpler and have better defaults.