### PR TITLE
refactor: remove bip39 mnemonic derivation (Keypair.fromMnemonicSeed)

### DIFF
--- a/libs/keypair/src/lib/keypair.fixture.ts
+++ b/libs/keypair/src/lib/keypair.fixture.ts
@@ -2,70 +2,21 @@ export const TEST_SECRET_KEY =
   '4j3PbCCYvcAz1FbKGs7fBoQ5cd8piWCsQm5k6wNnTTzEtE6aM8JZ2AJaaJTjZJgGk9LywyonNHcVopHAwrMqh6kr'
 export const TEST_PUBLIC_KEY = '5ZWj7a1f8tWkjBESHKgrLmXshuXxqeY9SYcfbshpAqPG'
 export const TEST_MNEMONIC_12 = 'pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter'
+export const TEST_MNEMONIC_12_KEYPAIR = {
+  mnemonic: TEST_MNEMONIC_12,
+  publicKey: '5F86TNSTre3CYwZd1wELsGQGhqG2HkN3d8zxhbyBSnzm',
+  secretKey: 'cWNhG6WhR4q6X5v8d65x6UgVR4buQJFkpKVvKiFDbbbZnoxpTJZLoCkCLZXpCYKc1QgyXYbhQpACYN8VKgS5xxq',
+}
 export const TEST_MNEMONIC_24 =
   'grab amused tattoo cruise industry corn welcome wealth tilt erupt gauge ankle remove toast journey heavy unit vibrant zoo blood notice jealous gesture cargo'
-export const TEST_MNEMONIC_24_SECRET_KEY =
-  'RkXUT99dpuSPP33w3X6tTx8KTDJMs1ce3tjeHWm2GSTKau7qFDN5BFMEeGToMGcEDunXuBpozxWAnr6uir8JVMD'
-export const TEST_MNEMONIC_24_PUBLIC_KEY = '36hssW7DqagnHyC3dPjD59kjiUnYWrYd8hXeQ3zZ5kUK'
-export const TEST_MNEMONIC_24_SET = [
-  {
-    mnemonic: TEST_MNEMONIC_24,
-    publicKey: '6pFBagvvyvBHuCkbMAiPTLn42nnHXrHC2zwWSdZ1NtVn',
-    secretKey: 'WTqijcBccatWsAA6WJzaqgNzJVdARiBHceL5DQG15RbZCNn9jeoEjwMyKRiQqsPvLKGhgkQMoUgo2ybbZmStU3r',
-  },
-  {
-    mnemonic: TEST_MNEMONIC_24,
-    publicKey: 'Foo948ttNuYa8SsfHX78BVyPVA7P7MsV8u43ZeQ1RBxm',
-    secretKey: 'TcauP27RkmyhH2AsVaPh5rCofCN4xCoB1h5MgUT6eRoJ7GiVPDBqtW1dAmh9CNcHSqCVnoEFUbRhfApM6oLrUDF',
-  },
-  {
-    mnemonic: TEST_MNEMONIC_24,
-    publicKey: '3ySWEh9mvVUpzMYYcqEv7VeAQp7ueGFAjUg1G9DBTjD5',
-    secretKey: '48wHgpEEb1f14kcYAyskTmUY9WnzLXuGUi1qmGiZr89uEmNo8g3uDNsk4aNjMaAfrE4oew7tk7VXWtUj8jWZGdbR',
-  },
-  {
-    mnemonic: TEST_MNEMONIC_24,
-    publicKey: 'HyMtaWzweBgpmgDf2dn8RhsM1c9m48VPQFjV6DAkHxbv',
-    secretKey: '46HfvZCsmSCnS9akRqULDci7313KQGk7Ndv7PXejTa4rnEtH7PnGMUo5jxkJwMJjifFxHyfJSkYcziEBqJqGPQYL',
-  },
-  {
-    mnemonic: TEST_MNEMONIC_24,
-    publicKey: '5SZcAkce1YHt5D4ANfxQGBo1fRcjn7jbCaUGgaBPz8or',
-    secretKey: '3Gr9wYRLhz9LLhkSTYy1TsXyUbDcsfhVUxpDxDrHSjdY2J1tNBQWRZ4qdFvbH5AiMJCvq9qhxZc6j1RinPXMWDMa',
-  },
-  {
-    mnemonic: TEST_MNEMONIC_24,
-    publicKey: '77VRnnzwRTeQLDpNDfMh8DrDkzbAtcuKncZyWN49oegG',
-    secretKey: 'vrMzreRiV8Abz2WxqZhgh2Hmg5Mnc65QD3P1tr5Y7a296d7Y4FrUBppGCUAz2qCa6iNVUjygZu4SMiRDmW59Vbe',
-  },
-  {
-    mnemonic: TEST_MNEMONIC_24,
-    publicKey: 'GRwsvJC92A9UB4eEcpzuxPqsuBdKRjd731uGp6BLbPJv',
-    secretKey: '4ZPFuK3dS189sJFXdTiVRXeVA7ZV4LPgUUgXJwx7WVWMVCpafG3L1D2j1Z4dSJzamyYruHCSYWrwP6s8HhGLTYS2',
-  },
-  {
-    mnemonic: TEST_MNEMONIC_24,
-    publicKey: 'piCoBHqPoK4dhg84g1NajB6vdJX785G3wT2rExaQ6Q3',
-    secretKey: '3iUkSFmpVM4rZUsMJqGH1ajY3tWxG9A64agQwaPCZ1m5Yc3V8JacEPnAu3oDdhxTARHnpXKBBVcDJhv9cR2JDvd9',
-  },
-  {
-    mnemonic: TEST_MNEMONIC_24,
-    publicKey: '6EeiyS9X6222PeUzpKA32jc3ZEkpTKms3qNZEmySm1DS',
-    secretKey: '8BJqbw31Zmn7887LtFtevmmGaUm5BNUvMB1tsnLdzCv5TFPTodYDCsKCFovHoL1BSZwGxbixDZoWwszLpSyYKXv',
-  },
-  {
-    mnemonic: TEST_MNEMONIC_24,
-    publicKey: 'DhW8bCabXWMJYg99rtZyy2XWax8J5wfLh8kmkpDxbR8G',
-    secretKey: '3P4zpjXuBtxH8hMguo8k68Nz3mDYRto3CaMkSm55TtPZzinRYg76uyvy2CBimcegBRThH92H9MzffYShJB62W8ya',
-  },
-]
+export const TEST_MNEMONIC_24_KEYPAIR = {
+  mnemonic: TEST_MNEMONIC_24,
+  publicKey: '6pFBagvvyvBHuCkbMAiPTLn42nnHXrHC2zwWSdZ1NtVn',
+  secretKey: 'WTqijcBccatWsAA6WJzaqgNzJVdARiBHceL5DQG15RbZCNn9jeoEjwMyKRiQqsPvLKGhgkQMoUgo2ybbZmStU3r',
+}
 
 export const TEST_MNEMONIC_12_SET = [
-  {
-    mnemonic: TEST_MNEMONIC_12,
-    publicKey: '5F86TNSTre3CYwZd1wELsGQGhqG2HkN3d8zxhbyBSnzm',
-    secretKey: 'cWNhG6WhR4q6X5v8d65x6UgVR4buQJFkpKVvKiFDbbbZnoxpTJZLoCkCLZXpCYKc1QgyXYbhQpACYN8VKgS5xxq',
-  },
+  TEST_MNEMONIC_12_KEYPAIR,
   {
     mnemonic: TEST_MNEMONIC_12,
     publicKey: 'AWjbG5SH5VEay5ksZbGHHgJhYRhM1rsN5Z538cfFvs4a',
@@ -113,14 +64,57 @@ export const TEST_MNEMONIC_12_SET = [
   },
 ]
 
+export const TEST_MNEMONIC_24_SET = [
+  TEST_MNEMONIC_24_KEYPAIR,
+  {
+    mnemonic: TEST_MNEMONIC_24,
+    publicKey: 'Foo948ttNuYa8SsfHX78BVyPVA7P7MsV8u43ZeQ1RBxm',
+    secretKey: 'TcauP27RkmyhH2AsVaPh5rCofCN4xCoB1h5MgUT6eRoJ7GiVPDBqtW1dAmh9CNcHSqCVnoEFUbRhfApM6oLrUDF',
+  },
+  {
+    mnemonic: TEST_MNEMONIC_24,
+    publicKey: '3ySWEh9mvVUpzMYYcqEv7VeAQp7ueGFAjUg1G9DBTjD5',
+    secretKey: '48wHgpEEb1f14kcYAyskTmUY9WnzLXuGUi1qmGiZr89uEmNo8g3uDNsk4aNjMaAfrE4oew7tk7VXWtUj8jWZGdbR',
+  },
+  {
+    mnemonic: TEST_MNEMONIC_24,
+    publicKey: 'HyMtaWzweBgpmgDf2dn8RhsM1c9m48VPQFjV6DAkHxbv',
+    secretKey: '46HfvZCsmSCnS9akRqULDci7313KQGk7Ndv7PXejTa4rnEtH7PnGMUo5jxkJwMJjifFxHyfJSkYcziEBqJqGPQYL',
+  },
+  {
+    mnemonic: TEST_MNEMONIC_24,
+    publicKey: '5SZcAkce1YHt5D4ANfxQGBo1fRcjn7jbCaUGgaBPz8or',
+    secretKey: '3Gr9wYRLhz9LLhkSTYy1TsXyUbDcsfhVUxpDxDrHSjdY2J1tNBQWRZ4qdFvbH5AiMJCvq9qhxZc6j1RinPXMWDMa',
+  },
+  {
+    mnemonic: TEST_MNEMONIC_24,
+    publicKey: '77VRnnzwRTeQLDpNDfMh8DrDkzbAtcuKncZyWN49oegG',
+    secretKey: 'vrMzreRiV8Abz2WxqZhgh2Hmg5Mnc65QD3P1tr5Y7a296d7Y4FrUBppGCUAz2qCa6iNVUjygZu4SMiRDmW59Vbe',
+  },
+  {
+    mnemonic: TEST_MNEMONIC_24,
+    publicKey: 'GRwsvJC92A9UB4eEcpzuxPqsuBdKRjd731uGp6BLbPJv',
+    secretKey: '4ZPFuK3dS189sJFXdTiVRXeVA7ZV4LPgUUgXJwx7WVWMVCpafG3L1D2j1Z4dSJzamyYruHCSYWrwP6s8HhGLTYS2',
+  },
+  {
+    mnemonic: TEST_MNEMONIC_24,
+    publicKey: 'piCoBHqPoK4dhg84g1NajB6vdJX785G3wT2rExaQ6Q3',
+    secretKey: '3iUkSFmpVM4rZUsMJqGH1ajY3tWxG9A64agQwaPCZ1m5Yc3V8JacEPnAu3oDdhxTARHnpXKBBVcDJhv9cR2JDvd9',
+  },
+  {
+    mnemonic: TEST_MNEMONIC_24,
+    publicKey: '6EeiyS9X6222PeUzpKA32jc3ZEkpTKms3qNZEmySm1DS',
+    secretKey: '8BJqbw31Zmn7887LtFtevmmGaUm5BNUvMB1tsnLdzCv5TFPTodYDCsKCFovHoL1BSZwGxbixDZoWwszLpSyYKXv',
+  },
+  {
+    mnemonic: TEST_MNEMONIC_24,
+    publicKey: 'DhW8bCabXWMJYg99rtZyy2XWax8J5wfLh8kmkpDxbR8G',
+    secretKey: '3P4zpjXuBtxH8hMguo8k68Nz3mDYRto3CaMkSm55TtPZzinRYg76uyvy2CBimcegBRThH92H9MzffYShJB62W8ya',
+  },
+]
+
 export const TEST_SECRET_BYTEARRAY = [
   186, 78, 68, 54, 63, 205, 1, 141, 2, 89, 45, 80, 77, 168, 215, 120, 56, 57, 72, 222, 50, 140, 31, 236, 254, 35, 208,
   163, 138, 186, 225, 18, 67, 194, 241, 235, 28, 5, 209, 235, 248, 58, 150, 42, 218, 71, 43, 177, 183, 62, 55, 96, 216,
   41, 59, 146, 121, 132, 223, 24, 39, 109, 3, 163,
-]
-
-export const TEST_MNEMONIC_24_SECRET_BYTEARRAY = [
-  21, 88, 5, 199, 169, 213, 220, 156, 74, 197, 135, 91, 234, 239, 79, 239, 83, 183, 38, 98, 138, 47, 96, 142, 215, 172,
-  1, 11, 198, 221, 205, 119, 31, 45, 127, 109, 74, 35, 24, 201, 119, 78, 115, 217, 250, 127, 206, 222, 152, 155, 203,
-  137, 58, 69, 92, 27, 0, 193, 197, 31, 62, 73, 253, 124,
 ]

--- a/libs/keypair/src/lib/keypair.spec.ts
+++ b/libs/keypair/src/lib/keypair.spec.ts
@@ -1,16 +1,15 @@
+import { Keypair } from './keypair'
 import {
   TEST_MNEMONIC_12,
+  TEST_MNEMONIC_12_KEYPAIR,
   TEST_MNEMONIC_12_SET,
   TEST_MNEMONIC_24,
-  TEST_MNEMONIC_24_PUBLIC_KEY,
-  TEST_MNEMONIC_24_SECRET_KEY,
+  TEST_MNEMONIC_24_KEYPAIR,
   TEST_MNEMONIC_24_SET,
-  TEST_MNEMONIC_24_SECRET_BYTEARRAY,
   TEST_PUBLIC_KEY,
   TEST_SECRET_BYTEARRAY,
   TEST_SECRET_KEY,
 } from './keypair.fixture'
-import { Keypair } from './keypair'
 
 describe('Keypair', () => {
   it('should generate a KeyPair', () => {
@@ -65,35 +64,51 @@ describe('Keypair', () => {
   it('should create and import keypair', () => {
     const kp1 = Keypair.random()
     const kp2 = Keypair.fromSecretKey(kp1.secretKey)
+    const kpSecret = Keypair.fromSecret(kp1.secretKey)
+
     expect(kp1.secretKey).toEqual(kp2.secretKey)
     expect(kp1.publicKey).toEqual(kp2.publicKey)
+    expect(kpSecret.publicKey).toEqual(kp2.publicKey)
   })
 
   it('should import from a bytearray', () => {
     const kp = Keypair.fromByteArray(TEST_SECRET_BYTEARRAY)
+    const kpSecret = Keypair.fromSecret(`[${TEST_SECRET_BYTEARRAY}]`)
 
     expect(kp.publicKey).toEqual(TEST_PUBLIC_KEY)
+    expect(kpSecret.publicKey).toEqual(TEST_PUBLIC_KEY)
   })
 
   it('should import and existing secret', () => {
     const kp = Keypair.fromSecretKey(TEST_SECRET_KEY)
+    const kpSecret = Keypair.fromSecret(TEST_SECRET_KEY)
+
     expect(kp.publicKey).toEqual(TEST_PUBLIC_KEY)
+    expect(kpSecret.publicKey).toEqual(TEST_PUBLIC_KEY)
   })
 
-  it('should import from a mnemonic (12)', () => {
-    const keypair = Keypair.fromMnemonicSeed(TEST_MNEMONIC_12)
-    expect(keypair.secretKey).toEqual(TEST_SECRET_KEY)
-    expect(keypair.solanaSecretKey.toString()).toEqual(TEST_SECRET_BYTEARRAY.toString())
-    expect(keypair.solanaPublicKey.toBase58()).toEqual(TEST_PUBLIC_KEY)
-    expect(keypair.publicKey).toEqual(TEST_PUBLIC_KEY)
+  it('should import a mnemonic (12 chars) and get 1 keypair', () => {
+    const kp = Keypair.fromMnemonic(TEST_MNEMONIC_12)
+    const kpSecret = Keypair.fromSecret(TEST_MNEMONIC_12)
+
+    expect(kp.mnemonic).toEqual(TEST_MNEMONIC_12_KEYPAIR.mnemonic)
+    expect(kpSecret.mnemonic).toEqual(TEST_MNEMONIC_12_KEYPAIR.mnemonic)
+    expect(kp.publicKey).toEqual(TEST_MNEMONIC_12_KEYPAIR.publicKey)
+    expect(kpSecret.publicKey).toEqual(TEST_MNEMONIC_12_KEYPAIR.publicKey)
+    expect(kp.secretKey).toEqual(TEST_MNEMONIC_12_KEYPAIR.secretKey)
+    expect(kpSecret.secretKey).toEqual(TEST_MNEMONIC_12_KEYPAIR.secretKey)
   })
 
-  it('should import from a mnemonic (24)', () => {
-    const keypair = Keypair.fromMnemonicSeed(TEST_MNEMONIC_24)
-    expect(keypair.secretKey).toEqual(TEST_MNEMONIC_24_SECRET_KEY)
-    expect(keypair.solanaSecretKey.toString()).toEqual(TEST_MNEMONIC_24_SECRET_BYTEARRAY.toString())
-    expect(keypair.solanaPublicKey.toBase58()).toEqual(TEST_MNEMONIC_24_PUBLIC_KEY)
-    expect(keypair.publicKey).toEqual(TEST_MNEMONIC_24_PUBLIC_KEY)
+  it('should import a mnemonic (24 chars) and get 1 keypair', () => {
+    const kp = Keypair.fromMnemonic(TEST_MNEMONIC_24)
+    const kpSecret = Keypair.fromSecret(TEST_MNEMONIC_24)
+
+    expect(kp.mnemonic).toEqual(TEST_MNEMONIC_24_KEYPAIR.mnemonic)
+    expect(kpSecret.mnemonic).toEqual(TEST_MNEMONIC_24_KEYPAIR.mnemonic)
+    expect(kp.publicKey).toEqual(TEST_MNEMONIC_24_KEYPAIR.publicKey)
+    expect(kpSecret.publicKey).toEqual(TEST_MNEMONIC_24_KEYPAIR.publicKey)
+    expect(kp.secretKey).toEqual(TEST_MNEMONIC_24_KEYPAIR.secretKey)
+    expect(kpSecret.secretKey).toEqual(TEST_MNEMONIC_24_KEYPAIR.secretKey)
   })
 
   it(`should create at least one keypair, even if the 'from' and 'to' params are not properly used`, () => {
@@ -102,7 +117,7 @@ describe('Keypair', () => {
   })
 
   it('should import multiple from a mnemonic (12 chars)', () => {
-    const set = Keypair.fromMnemonicSet(TEST_MNEMONIC_12)
+    const set = Keypair.fromMnemonicSet(TEST_MNEMONIC_12, 0, 10)
     const keys = set.map(({ mnemonic, secretKey, publicKey }) => ({
       mnemonic,
       secretKey,
@@ -115,7 +130,7 @@ describe('Keypair', () => {
   })
 
   it('should import multiple from a mnemonic (24 chars)', () => {
-    const set = Keypair.fromMnemonicSet(TEST_MNEMONIC_24)
+    const set = Keypair.fromMnemonicSet(TEST_MNEMONIC_24, 0, 10)
     const keys = set.map(({ mnemonic, secretKey, publicKey }) => ({
       mnemonic,
       secretKey,
@@ -129,6 +144,8 @@ describe('Keypair', () => {
 
   it('should throw an error when we put in unexpected values', () => {
     expect(() => new Keypair('123')).toThrow()
-    expect(() => Keypair.fromMnemonicSeed('')).toThrow()
+    expect(() => Keypair.fromMnemonic('')).toThrow()
+    expect(() => Keypair.fromSecret('')).toThrow()
+    expect(() => Keypair.fromByteArray([])).toThrow()
   })
 })

--- a/libs/keypair/src/lib/keypair.ts
+++ b/libs/keypair/src/lib/keypair.ts
@@ -34,17 +34,11 @@ export class Keypair {
     return this.fromSecretKey(bs58.encode(Uint8Array.from(byteArray)))
   }
 
-  static fromMnemonicSeed(mnemonic: string): Keypair {
-    const seed = bip39.mnemonicToSeedSync(mnemonic, '')
-
-    return this.fromSeed(Buffer.from(seed).slice(0, 32))
-  }
-
   static fromMnemonic(mnemonic: string): Keypair {
     return this.fromMnemonicSet(mnemonic)[0]
   }
 
-  static fromMnemonicSet(mnemonic: string, from = 0, to = 10): Keypair[] {
+  static fromMnemonicSet(mnemonic: string, from = 0, to = 1): Keypair[] {
     // Always start with zero as minimum
     from = from < 0 ? 0 : from
     // Always generate at least 1
@@ -64,6 +58,7 @@ export class Keypair {
 
   static derive(seed: Buffer, path: string): Keypair {
     const hd = HDKey.fromMasterSeed(seed.toString('hex'))
+
     return Keypair.fromSeed(Buffer.from(hd.derive(path).privateKey))
   }
 


### PR DESCRIPTION
The `Keypair` class featured a method `Keypair.fromMnemonicSeed()` that used `bip39` derivation. Those mnemonics are compatible with the ones created by `solana-keygen` (`solana-keygen new --no-bip39-passphrase --no-outfile`) but are not compatible with the rest of the ecosystem, who is using `bip44` to derive the keypairs.

To avoid any confusion, we will remove the `bip39` derivation from any of our SDKs, making the only available option the one that's compatible with the larger Solana ecosystem. 


If you ever need this, it's pretty simple to implement so it doesn't seem to be a big loss to not ship this on `Keypair`.

```ts
import * as bip39 from '@scure/bip39'

function fromMnemonicSeed(mnemonic: string): Keypair {
  const seed = bip39.mnemonicToSeedSync(mnemonic, '')

  return Keypair.fromSeed(Buffer.from(seed).slice(0, 32))
}
```