### PR TITLE
fix: point codegen.yml to http://127.0.0.1:3000/graphql

### DIFF
--- a/libs/web/util/sdk/src/codegen.yml
+++ b/libs/web/util/sdk/src/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'http://localhost:3000/graphql'
+schema: 'http://127.0.0.1:3000/graphql'
 documents:
   - 'libs/web/util/sdk/src/graphql/**/*.graphql'
 generates:


### PR DESCRIPTION
Got this error after updating to Node 18:

```
      Failed to load schema from http://localhost:3000/graphql:
      fetch failed
      TypeError: fetch failed
      at Object.fetch (node:internal/deps/undici/undici:11118:11)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async UrlLoader.load (/Users/beeman/kin/kin-labs/kinetic/node_modules/@graphql-tools/url-loader/cjs/index.js:562:29)
      at async /Users/beeman/kin/kin-labs/kinetic/node_modules/@graphql-tools/load/cjs/load-typedefs/load-file.js:17:39
```

[The fix](https://github.com/dotansimha/graphql-code-generator/issues/7396#issuecomment-1070318950) seems to be pointing it to 127.0.0.1.