### PR TITLE
fix: make sure SDK doesn't swallow connectiong error messages

### DIFF
--- a/libs/sdk/src/lib/kinetic-sdk-internal.ts
+++ b/libs/sdk/src/lib/kinetic-sdk-internal.ts
@@ -96,9 +96,13 @@ export class KineticSdkInternal {
   }
 
   async getAppConfig(environment: string, index: number) {
-    const res = await this.appApi.getAppConfig(environment, index)
-    this.appConfig = res.data
-    return this.appConfig
+    return this.appApi
+      .getAppConfig(environment, index)
+      .then((res) => res.data)
+      .then((appConfig) => {
+        this.appConfig = appConfig
+        return this.appConfig
+      })
   }
 
   async getBalance(options: GetBalanceOptions): Promise<BalanceResponse> {

--- a/libs/sdk/src/lib/kinetic-sdk.ts
+++ b/libs/sdk/src/lib/kinetic-sdk.ts
@@ -88,7 +88,8 @@ export class KineticSdk {
       )
       return config
     } catch (e) {
-      this.sdkConfig?.logger?.error(`Error initializing Server.`)
+      console.error(`${NAME}: Error initializing SDK: ${e}`)
+      this.sdkConfig?.logger?.error(`Error initializing Server: ${e}`)
       throw new Error(`Error initializing Server.`)
     }
   }
@@ -96,9 +97,12 @@ export class KineticSdk {
   static async setup(config: KineticSdkConfig): Promise<KineticSdk> {
     const sdk = new KineticSdk(validateKineticSdkConfig(config))
     try {
-      await sdk.init().then(() => config.logger?.log(`${NAME}: Setup done.`))
-      return sdk
+      return sdk.init().then(() => {
+        config.logger?.log(`${NAME}: Setup done.`)
+        return sdk
+      })
     } catch (e) {
+      console.error(`${NAME}: Error setting up Kinetic SDK: ${e}`)
       config.logger?.error(`${NAME}: Error setting up SDK.`, e)
       throw new Error(`${NAME}: Error setting up SDK.`)
     }


### PR DESCRIPTION
Currently the SDK swallows error messages because it used `async`/`await` without try/catch. This patch moves it to a normal promise chain, the errors now propagate as desired:

![image](https://user-images.githubusercontent.com/36491/204388779-484f5f5c-b7c8-4884-9054-7ce81d825607.png)
