### PR TITLE
fix: make KineticSdk throw clean error messages instead of response object

### DIFF
--- a/apps/sdk-e2e/src/integration/account-kinetic-sdk-e2e.spec.ts
+++ b/apps/sdk-e2e/src/integration/account-kinetic-sdk-e2e.spec.ts
@@ -101,21 +101,16 @@ describe('KineticSdk (e2e) - Account', () => {
     expect(tokenAccounts[0]).toBe('Ebq6K7xVh6PYQ8DrTQnD9fC91uQiyBMPGSV6JCG6GPdD')
   })
 
-  it('should throw an error when publicKey does not exits or is incorrect', async () => {
-    try {
-      await sdk.getBalance({ account: 'xx' })
-    } catch (error) {
-      expect(error.response.data.statusCode).toBe(400)
-      expect(error.response.data.message).toBe('Error: accountId must be a valid PublicKey')
-    }
+  it('should throw an error when publicKey does not exit or is incorrect', async () => {
+    await expect(async () => await sdk.getBalance({ account: 'xx' })).rejects.toThrow(
+      'accountId must be a valid PublicKey',
+    )
   })
 
   it('should throw when try to create an account that already exists', async () => {
-    try {
-      await sdk.createAccount({ owner: daveKeypair })
-    } catch (e) {
-      expect(e.message).toEqual(`Owner ${daveKeypair.publicKey} already has an account for mint ${DEFAULT_MINT}.`)
-    }
+    await expect(async () => await sdk.createAccount({ owner: daveKeypair })).rejects.toThrow(
+      `Owner ${daveKeypair.publicKey} already has an account for mint ${DEFAULT_MINT}.`,
+    )
   })
 
   it('should get the account history with a provided mint', async () => {

--- a/apps/sdk-e2e/src/integration/airdrop-kinetic-sdk-e2e.spec.ts
+++ b/apps/sdk-e2e/src/integration/airdrop-kinetic-sdk-e2e.spec.ts
@@ -21,10 +21,8 @@ describe('KineticSdk (e2e) - Airdrop', () => {
   }, 30000)
 
   it('should fail when airdrop request exceeds maximum allowed', async () => {
-    try {
-      await sdk.requestAirdrop({ account: daveKeypair.publicKey, amount: '50001' })
-    } catch (error) {
-      expect(error.response.data.message).toBe('Error: Try requesting 50000 or less.')
-    }
+    await expect(
+      async () => await sdk.requestAirdrop({ account: daveKeypair.publicKey, amount: '50001' }),
+    ).rejects.toThrow('Try requesting 50000 or less.')
   })
 })

--- a/libs/api/airdrop/data-access/src/lib/api-airdrop-data-access.service.ts
+++ b/libs/api/airdrop/data-access/src/lib/api-airdrop-data-access.service.ts
@@ -1,7 +1,7 @@
 import { Airdrop } from '@kin-kinetic/api/airdrop/util'
 import { ApiCoreDataAccessService } from '@kin-kinetic/api/core/data-access'
 import { Commitment } from '@kin-kinetic/solana'
-import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common'
+import { BadRequestException, Injectable, Logger } from '@nestjs/common'
 import { RequestAirdropRequest } from './dto/request-airdrop-request.dto'
 import { RequestAirdropResponse } from './entity/request-airdrop-response.entity'
 
@@ -20,14 +20,14 @@ export class ApiAirdropDataAccessService {
     // Make sure the requested mint is enabled for this app
     const appMint = appEnv.mints.find((mint) => mint.mint.address === request.mint)
     if (!appMint) {
-      throw new Error(`Can't find mint ${request.mint} in environment ${environment} for index ${index}`)
+      throw new BadRequestException(`Can't find mint ${request.mint} in environment ${environment} for index ${index}`)
     }
     const mint = appMint.mint
 
     // Make sure there is an airdrop config for this mint
     const airdropConfig = this.data.getAirdropConfig(mint, appEnv.cluster)
     if (!airdropConfig) {
-      throw new HttpException(`Airdrop configuration not found.`, HttpStatus.BAD_REQUEST)
+      throw new BadRequestException(`Airdrop configuration not found.`)
     }
 
     // Make sure there is an Airdrop configured with a Solana connection
@@ -54,7 +54,7 @@ export class ApiAirdropDataAccessService {
       }
     } catch (error) {
       this.logger.error(error)
-      throw new HttpException(`${error}`, HttpStatus.BAD_REQUEST)
+      throw error
     }
   }
 }

--- a/libs/api/airdrop/util/src/lib/airdrop.ts
+++ b/libs/api/airdrop/util/src/lib/airdrop.ts
@@ -1,4 +1,5 @@
 import { Commitment, convertCommitment, getPublicKey, PublicKeyString } from '@kin-kinetic/solana'
+import { BadRequestException } from '@nestjs/common'
 import { createAssociatedTokenAccount, transferChecked } from '@solana/spl-token'
 import { Connection, Keypair, PublicKey } from '@solana/web3.js'
 import { AirdropConfig } from './airdrop-config'
@@ -18,7 +19,7 @@ export class Airdrop {
   async airdrop(account: PublicKeyString, amount?: number | string, commitment?: Commitment): Promise<AirdropResponse> {
     amount = amount && amount?.toString()?.length && Number(amount) > 0 ? Number(amount) : this.config.airdropAmount
     if (Number(amount) > this.config.airdropMax) {
-      throw new Error(`Try requesting ${this.config.airdropMax} or less.`)
+      throw new BadRequestException(`Try requesting ${this.config.airdropMax} or less.`)
     }
     // Get Fee Payer Accounts
     const fromOwner = this.feePayer.publicKey.toBase58()

--- a/libs/api/core/util/src/lib/public-key.pipe.ts
+++ b/libs/api/core/util/src/lib/public-key.pipe.ts
@@ -10,7 +10,7 @@ export class PublicKeyPipe implements PipeTransform {
     try {
       new PublicKey(value)
     } catch (error) {
-      throw new HttpException(`Error: ${this.field} must be a valid PublicKey`, HttpStatus.BAD_REQUEST)
+      throw new HttpException(`${this.field} must be a valid PublicKey`, HttpStatus.BAD_REQUEST)
     }
 
     return value

--- a/libs/api/transaction/data-access/src/lib/api-transaction-data-access.service.ts
+++ b/libs/api/transaction/data-access/src/lib/api-transaction-data-access.service.ts
@@ -2,7 +2,7 @@ import { ApiCoreDataAccessService, AppEnvironment } from '@kin-kinetic/api/core/
 import { ApiWebhookDataAccessService, WebhookType } from '@kin-kinetic/api/webhook/data-access'
 import { Keypair } from '@kin-kinetic/keypair'
 import { Commitment, parseAndSignTokenTransfer, removeDecimals, Solana } from '@kin-kinetic/solana'
-import { Injectable, Logger, OnModuleInit, UnauthorizedException } from '@nestjs/common'
+import { BadRequestException, Injectable, Logger, OnModuleInit, UnauthorizedException } from '@nestjs/common'
 import { Counter } from '@opentelemetry/api-metrics'
 import {
   App,
@@ -178,7 +178,7 @@ export class ApiTransactionDataAccessService implements OnModuleInit {
     const found = appEnv.mints.find(({ mint }) => mint.address === inputMint)
     if (!found) {
       this.makeTransferMintNotFoundErrorCounter.add(1, { appKey, mint: inputMint.toString() })
-      throw new Error(`${appKey}: Can't find mint ${inputMint}`)
+      throw new BadRequestException(`${appKey}: Can't find mint ${inputMint}`)
     }
     return found
   }

--- a/libs/sdk/src/lib/kinetic-sdk-internal.ts
+++ b/libs/sdk/src/lib/kinetic-sdk-internal.ts
@@ -119,7 +119,12 @@ export class KineticSdkInternal {
       tx: serializeTransaction(tx),
     }
 
-    return this.accountApi.createAccount(request).then((res) => res.data)
+    return this.accountApi
+      .createAccount(request)
+      .then((res) => res.data)
+      .catch((err) => {
+        throw new Error(err?.response?.data?.message ?? 'Unknown error')
+      })
   }
 
   getAccountInfo(options: GetAccountInfoOptions) {
@@ -136,12 +141,18 @@ export class KineticSdkInternal {
         this.appConfig = appConfig
         return this.appConfig
       })
+      .catch((err) => {
+        throw new Error(err?.response?.data?.message ?? 'Unknown error')
+      })
   }
 
   async getBalance(options: GetBalanceOptions): Promise<BalanceResponse> {
     return this.accountApi
       .getBalance(this.sdkConfig.environment, this.sdkConfig.index, options.account.toString())
       .then((res) => res.data)
+      .catch((err) => {
+        throw new Error(err?.response?.data?.message ?? 'Unknown error')
+      })
   }
 
   getHistory(options: GetHistoryOptions): Promise<HistoryResponse[]> {
@@ -151,6 +162,9 @@ export class KineticSdkInternal {
     return this.accountApi
       .getHistory(this.sdkConfig.environment, this.sdkConfig.index, options.account.toString(), mint.publicKey)
       .then((res) => res.data)
+      .catch((err) => {
+        throw new Error(err?.response?.data?.message ?? 'Unknown error')
+      })
   }
 
   getTokenAccounts(options: GetTokenAccountsOptions): Promise<string[]> {
@@ -160,12 +174,18 @@ export class KineticSdkInternal {
     return this.accountApi
       .getTokenAccounts(this.sdkConfig.environment, this.sdkConfig.index, options.account.toString(), mint.publicKey)
       .then((res) => res.data)
+      .catch((err) => {
+        throw new Error(err?.response?.data?.message ?? 'Unknown error')
+      })
   }
 
   getTransaction(options: GetTransactionOptions) {
     return this.transactionApi
       .getTransaction(this.sdkConfig.environment, this.sdkConfig.index, options.signature)
       .then((res) => res.data)
+      .catch((err) => {
+        throw new Error(err?.response?.data?.message ?? 'Unknown error')
+      })
   }
 
   async makeTransfer(options: MakeTransferOptions) {
@@ -210,6 +230,8 @@ export class KineticSdkInternal {
       referenceId: options.referenceId,
       referenceType: options.referenceType,
       tx: serializeTransaction(tx),
+    }).catch((err) => {
+      throw new Error(err?.response?.data?.message ?? 'Unknown error')
     })
   }
 
@@ -248,6 +270,8 @@ export class KineticSdkInternal {
       referenceId,
       referenceType,
       tx: serializeTransaction(tx),
+    }).catch((err) => {
+      throw new Error(err?.response?.data?.message ?? 'Unknown error')
     })
   }
 
@@ -265,6 +289,9 @@ export class KineticSdkInternal {
         mint: mint.publicKey,
       })
       .then((res) => res.data)
+      .catch((err) => {
+        throw new Error(err?.response?.data?.message ?? 'Unknown error')
+      })
   }
 
   private apiBaseOptions(headers: Record<string, string> = {}): AxiosRequestConfig {


### PR DESCRIPTION
This patch fixes the issue that the SDK currently returns the raw Axios response object with the errors hidden deep inside. Instead, errors now return a string with the error message or 'Unknown error'.