### PR TITLE
feat: implement api-solana-data-access app to prepare for caching

### DIFF
--- a/libs/api/account/data-access/src/lib/api-account-data-access.module.ts
+++ b/libs/api/account/data-access/src/lib/api-account-data-access.module.ts
@@ -1,11 +1,12 @@
 import { ApiAppDataAccessModule } from '@kin-kinetic/api/app/data-access'
 import { ApiCoreDataAccessModule } from '@kin-kinetic/api/core/data-access'
+import { ApiSolanaDataAccessModule } from '@kin-kinetic/api/solana/data-access'
 import { ApiTransactionDataAccessModule } from '@kin-kinetic/api/transaction/data-access'
 import { Module } from '@nestjs/common'
 import { ApiAccountDataAccessService } from './api-account-data-access.service'
 
 @Module({
-  imports: [ApiAppDataAccessModule, ApiCoreDataAccessModule, ApiTransactionDataAccessModule],
+  imports: [ApiAppDataAccessModule, ApiCoreDataAccessModule, ApiSolanaDataAccessModule, ApiTransactionDataAccessModule],
   providers: [ApiAccountDataAccessService],
   exports: [ApiAccountDataAccessService],
 })

--- a/libs/api/account/data-access/src/lib/api-account-data-access.service.spec.ts
+++ b/libs/api/account/data-access/src/lib/api-account-data-access.service.spec.ts
@@ -1,5 +1,6 @@
 import { ApiAppDataAccessModule } from '@kin-kinetic/api/app/data-access'
 import { ApiCoreDataAccessModule } from '@kin-kinetic/api/core/data-access'
+import { ApiSolanaDataAccessModule } from '@kin-kinetic/api/solana/data-access'
 import { ApiTransactionDataAccessModule } from '@kin-kinetic/api/transaction/data-access'
 import { Test } from '@nestjs/testing'
 import { ApiAccountDataAccessService } from './api-account-data-access.service'
@@ -9,7 +10,12 @@ describe('ApiAccountDataAccessService', () => {
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      imports: [ApiAppDataAccessModule, ApiCoreDataAccessModule, ApiTransactionDataAccessModule],
+      imports: [
+        ApiAppDataAccessModule,
+        ApiCoreDataAccessModule,
+        ApiSolanaDataAccessModule,
+        ApiTransactionDataAccessModule,
+      ],
       providers: [ApiAccountDataAccessService],
     }).compile()
 

--- a/libs/api/account/data-access/src/lib/api-account-data-access.service.ts
+++ b/libs/api/account/data-access/src/lib/api-account-data-access.service.ts
@@ -1,5 +1,6 @@
 import { ApiAppDataAccessService } from '@kin-kinetic/api/app/data-access'
 import { ApiCoreDataAccessService, AppEnvironment } from '@kin-kinetic/api/core/data-access'
+import { ApiSolanaDataAccessService } from '@kin-kinetic/api/solana/data-access'
 import {
   ApiTransactionDataAccessService,
   Transaction,
@@ -37,6 +38,7 @@ export class ApiAccountDataAccessService implements OnModuleInit {
   constructor(
     readonly data: ApiCoreDataAccessService,
     private readonly app: ApiAppDataAccessService,
+    private readonly solana: ApiSolanaDataAccessService,
     private readonly transaction: ApiTransactionDataAccessService,
   ) {}
 
@@ -151,7 +153,7 @@ export class ApiAccountDataAccessService implements OnModuleInit {
   }
 
   async getAccountInfo(environment: string, index: number, accountId: PublicKeyString) {
-    const solana = await this.data.getSolanaConnection(environment, index)
+    const solana = await this.solana.getConnection(environment, index)
     const account = getPublicKey(accountId)
     const accountInfo = await solana.connection.getParsedAccountInfo(account)
 
@@ -211,7 +213,7 @@ export class ApiAccountDataAccessService implements OnModuleInit {
     accountId: PublicKeyString,
     commitment: Commitment,
   ): Promise<BalanceSummary> {
-    const solana = await this.data.getSolanaConnection(environment, index)
+    const solana = await this.solana.getConnection(environment, index)
     const appEnv = await this.app.getAppConfig(environment, index)
 
     const mints: BalanceMint[] = appEnv.mints.map(({ decimals, publicKey }) => ({ decimals, publicKey }))
@@ -225,7 +227,7 @@ export class ApiAccountDataAccessService implements OnModuleInit {
     accountId: PublicKeyString,
     mint?: PublicKeyString,
   ): Promise<HistoryResponse[]> {
-    const solana = await this.data.getSolanaConnection(environment, index)
+    const solana = await this.solana.getConnection(environment, index)
     const appEnv = await this.app.getAppConfig(environment, index)
     mint = mint || appEnv.mint.publicKey
 
@@ -238,7 +240,7 @@ export class ApiAccountDataAccessService implements OnModuleInit {
     accountId: PublicKeyString,
     mint?: PublicKeyString,
   ): Promise<string[]> {
-    const solana = await this.data.getSolanaConnection(environment, index)
+    const solana = await this.solana.getConnection(environment, index)
     const appEnv = await this.app.getAppConfig(environment, index)
     mint = mint || appEnv.mint.publicKey
 

--- a/libs/api/airdrop/data-access/src/lib/api-airdrop-data-access.module.ts
+++ b/libs/api/airdrop/data-access/src/lib/api-airdrop-data-access.module.ts
@@ -1,10 +1,11 @@
+import { ApiCoreDataAccessModule } from '@kin-kinetic/api/core/data-access'
+import { ApiSolanaDataAccessModule } from '@kin-kinetic/api/solana/data-access'
 import { Module } from '@nestjs/common'
 import { ApiAirdropDataAccessService } from './api-airdrop-data-access.service'
-import { ApiCoreDataAccessModule } from '@kin-kinetic/api/core/data-access'
 
 @Module({
   providers: [ApiAirdropDataAccessService],
   exports: [ApiAirdropDataAccessService],
-  imports: [ApiCoreDataAccessModule],
+  imports: [ApiCoreDataAccessModule, ApiSolanaDataAccessModule],
 })
 export class ApiAirdropDataAccessModule {}

--- a/libs/api/airdrop/data-access/src/lib/api-airdrop-data-access.service.spec.ts
+++ b/libs/api/airdrop/data-access/src/lib/api-airdrop-data-access.service.spec.ts
@@ -1,4 +1,5 @@
 import { ApiCoreDataAccessModule } from '@kin-kinetic/api/core/data-access'
+import { ApiSolanaDataAccessModule } from '@kin-kinetic/api/solana/data-access'
 import { Test } from '@nestjs/testing'
 import { ApiAirdropDataAccessService } from './api-airdrop-data-access.service'
 
@@ -7,7 +8,7 @@ describe('ApiAirdropDataAccessService', () => {
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      imports: [ApiCoreDataAccessModule],
+      imports: [ApiCoreDataAccessModule, ApiSolanaDataAccessModule],
       providers: [ApiAirdropDataAccessService],
     }).compile()
 

--- a/libs/api/airdrop/data-access/src/lib/api-airdrop-data-access.service.ts
+++ b/libs/api/airdrop/data-access/src/lib/api-airdrop-data-access.service.ts
@@ -1,5 +1,6 @@
 import { Airdrop } from '@kin-kinetic/api/airdrop/util'
 import { ApiCoreDataAccessService } from '@kin-kinetic/api/core/data-access'
+import { ApiSolanaDataAccessService } from '@kin-kinetic/api/solana/data-access'
 import { Commitment } from '@kin-kinetic/solana'
 import { BadRequestException, Injectable, Logger } from '@nestjs/common'
 import { RequestAirdropRequest } from './dto/request-airdrop-request.dto'
@@ -10,11 +11,11 @@ export class ApiAirdropDataAccessService {
   private readonly airdrop = new Map<string, Airdrop>()
   private readonly logger = new Logger(ApiAirdropDataAccessService.name)
 
-  constructor(private readonly data: ApiCoreDataAccessService) {}
+  constructor(private readonly data: ApiCoreDataAccessService, private readonly solana: ApiSolanaDataAccessService) {}
 
   async requestAirdrop(request: RequestAirdropRequest): Promise<RequestAirdropResponse> {
     const { environment, index } = request
-    const solana = await this.data.getSolanaConnection(environment, index)
+    const solana = await this.solana.getConnection(environment, index)
     const appEnv = await this.data.getAppByEnvironmentIndex(environment, index)
 
     // Make sure the requested mint is enabled for this app

--- a/libs/api/app/data-access/src/lib/api-app-data-access.module.ts
+++ b/libs/api/app/data-access/src/lib/api-app-data-access.module.ts
@@ -1,4 +1,5 @@
 import { ApiCoreDataAccessModule } from '@kin-kinetic/api/core/data-access'
+import { ApiSolanaDataAccessModule } from '@kin-kinetic/api/solana/data-access'
 import { ApiWalletDataAccessModule } from '@kin-kinetic/api/wallet/data-access'
 import { Module } from '@nestjs/common'
 import { ApiAppAdminDataAccessService } from './api-app-admin-data-access.service'
@@ -22,6 +23,6 @@ import { ApiAppUserDataAccessService } from './api-app-user-data-access.service'
     ApiAppEnvUserDataAccessService,
     ApiAppUserDataAccessService,
   ],
-  imports: [ApiCoreDataAccessModule, ApiWalletDataAccessModule],
+  imports: [ApiCoreDataAccessModule, ApiSolanaDataAccessModule, ApiWalletDataAccessModule],
 })
 export class ApiAppDataAccessModule {}

--- a/libs/api/app/data-access/src/lib/api-app-data-access.service.spec.ts
+++ b/libs/api/app/data-access/src/lib/api-app-data-access.service.spec.ts
@@ -1,4 +1,5 @@
 import { ApiCoreDataAccessModule } from '@kin-kinetic/api/core/data-access'
+import { ApiSolanaDataAccessModule } from '@kin-kinetic/api/solana/data-access'
 import { ApiWalletDataAccessModule } from '@kin-kinetic/api/wallet/data-access'
 import { Test } from '@nestjs/testing'
 import { ApiAppDataAccessService } from './api-app-data-access.service'
@@ -8,7 +9,7 @@ describe('ApiAppDataAccessService', () => {
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      imports: [ApiCoreDataAccessModule, ApiWalletDataAccessModule],
+      imports: [ApiCoreDataAccessModule, ApiSolanaDataAccessModule, ApiWalletDataAccessModule],
       providers: [ApiAppDataAccessService],
     }).compile()
 

--- a/libs/api/app/data-access/src/lib/api-app-data-access.service.ts
+++ b/libs/api/app/data-access/src/lib/api-app-data-access.service.ts
@@ -1,4 +1,5 @@
 import { ApiCoreDataAccessService } from '@kin-kinetic/api/core/data-access'
+import { ApiSolanaDataAccessService } from '@kin-kinetic/api/solana/data-access'
 import { Injectable, Logger, NotFoundException, OnModuleInit } from '@nestjs/common'
 import { Counter } from '@opentelemetry/api-metrics'
 import { Prisma } from '@prisma/client'
@@ -37,7 +38,7 @@ export class ApiAppDataAccessService implements OnModuleInit {
   private getAppConfigErrorCounter: Counter
   private getAppConfigSuccessCounter: Counter
 
-  constructor(private readonly data: ApiCoreDataAccessService) {}
+  constructor(private readonly data: ApiCoreDataAccessService, private readonly solana: ApiSolanaDataAccessService) {}
 
   async onModuleInit() {
     this.getAppConfigErrorCounter = this.data.metrics.getCounter('api_app_get_app_config_error_counter', {
@@ -100,7 +101,7 @@ export class ApiAppDataAccessService implements OnModuleInit {
 
   async getAppHealth(environment: string, index: number): Promise<AppHealth> {
     const isKineticOk = true
-    const solana = await this.data.getSolanaConnection(environment, index)
+    const solana = await this.solana.getConnection(environment, index)
 
     const isSolanaOk = await solana.healthCheck()
 

--- a/libs/api/cluster/data-access/src/lib/api-cluster-admin-data-access.service.ts
+++ b/libs/api/cluster/data-access/src/lib/api-cluster-admin-data-access.service.ts
@@ -1,4 +1,5 @@
 import { ApiCoreDataAccessService } from '@kin-kinetic/api/core/data-access'
+import { ApiSolanaDataAccessService } from '@kin-kinetic/api/solana/data-access'
 import { Keypair } from '@kin-kinetic/keypair'
 import { BadRequestException, Injectable, Logger } from '@nestjs/common'
 import { MintType, Prisma } from '@prisma/client'
@@ -10,7 +11,7 @@ import { ClusterStatus } from './entity/cluster-status.enum'
 @Injectable()
 export class ApiClusterAdminDataAccessService {
   private readonly logger = new Logger(ApiClusterAdminDataAccessService.name)
-  constructor(private readonly data: ApiCoreDataAccessService) {}
+  constructor(private readonly data: ApiCoreDataAccessService, private readonly solana: ApiSolanaDataAccessService) {}
 
   async adminCreateCluster(userId: string, data: AdminClusterCreateInput) {
     await this.data.ensureAdminUser(userId)
@@ -76,9 +77,7 @@ export class ApiClusterAdminDataAccessService {
       include: { app: true },
     })
     for (const env of envs) {
-      const appKey = this.data.getAppKey(env.name, env.app.index)
-      this.data.connections.delete(appKey)
-      this.logger.log('Deleting cached connection for env', appKey)
+      this.solana.deleteConnection(env.name, env.app.index)
     }
     return updated
   }

--- a/libs/api/cluster/data-access/src/lib/api-cluster-data-access.module.ts
+++ b/libs/api/cluster/data-access/src/lib/api-cluster-data-access.module.ts
@@ -1,4 +1,5 @@
 import { ApiCoreDataAccessModule } from '@kin-kinetic/api/core/data-access'
+import { ApiSolanaDataAccessModule } from '@kin-kinetic/api/solana/data-access'
 import { Module } from '@nestjs/common'
 import { ApiClusterAdminDataAccessService } from './api-cluster-admin-data-access.service'
 import { ApiClusterUserDataAccessService } from './api-cluster-user-data-access.service'
@@ -6,6 +7,6 @@ import { ApiClusterUserDataAccessService } from './api-cluster-user-data-access.
 @Module({
   providers: [ApiClusterAdminDataAccessService, ApiClusterUserDataAccessService],
   exports: [ApiClusterAdminDataAccessService, ApiClusterUserDataAccessService],
-  imports: [ApiCoreDataAccessModule],
+  imports: [ApiCoreDataAccessModule, ApiSolanaDataAccessModule],
 })
 export class ApiClusterDataAccessModule {}

--- a/libs/api/core/data-access/src/lib/api-core-data-access.service.ts
+++ b/libs/api/core/data-access/src/lib/api-core-data-access.service.ts
@@ -2,9 +2,8 @@ import { AirdropConfig } from '@kin-kinetic/api/airdrop/util'
 import { hashPassword } from '@kin-kinetic/api/auth/util'
 import { ProvisionedCluster } from '@kin-kinetic/api/cluster/util'
 import { ApiConfigDataAccessService } from '@kin-kinetic/api/config/data-access'
-import { getVerboseLogger } from '@kin-kinetic/api/core/util'
 import { Keypair } from '@kin-kinetic/keypair'
-import { getPublicKey, Solana } from '@kin-kinetic/solana'
+import { getPublicKey } from '@kin-kinetic/solana'
 import { Injectable, Logger, NotFoundException, OnModuleInit, UnauthorizedException } from '@nestjs/common'
 import { Counter } from '@opentelemetry/api-metrics'
 import {
@@ -34,7 +33,6 @@ export type AppEnvironment = AppEnv & {
 export class ApiCoreDataAccessService extends PrismaClient implements OnModuleInit {
   private readonly logger = new Logger(ApiCoreDataAccessService.name)
   readonly airdropConfig = new Map<string, Omit<AirdropConfig, 'connection'>>()
-  readonly connections = new Map<string, Solana>()
 
   private getAppByEnvironmentIndexCounter: Counter
   private getAppByIndexCounter: Counter
@@ -227,21 +225,6 @@ export class ApiCoreDataAccessService extends PrismaClient implements OnModuleIn
 
   getAppKey(environment: string, index: number): string {
     return `app-${index}-${environment}`
-  }
-
-  async getSolanaConnection(environment: string, index: number): Promise<Solana> {
-    const appKey = this.getAppKey(environment, index)
-    if (!this.connections.has(appKey)) {
-      const env = await this.getAppByEnvironmentIndex(environment, index)
-      this.connections.set(
-        appKey,
-        new Solana(env.cluster.endpointPrivate, {
-          logger: getVerboseLogger(`@kin-kinetic/solana:${appKey}`),
-        }),
-      )
-      this.logger.log(`Created new connection for ${appKey}`)
-    }
-    return this.connections.get(appKey)
   }
 
   async getUserByEmail(email: string) {

--- a/libs/api/core/util/src/index.ts
+++ b/libs/api/core/util/src/index.ts
@@ -1,3 +1,2 @@
-export * from './lib/get-verbose-logger'
 export * from './lib/open-telemetry-sdk'
 export * from './lib/public-key.pipe'

--- a/libs/api/core/util/src/lib/get-verbose-logger.ts
+++ b/libs/api/core/util/src/lib/get-verbose-logger.ts
@@ -1,7 +1,0 @@
-import { Logger } from '@nestjs/common'
-
-export function getVerboseLogger(context: string) {
-  const logger = new Logger(context)
-
-  return { log: logger.verbose, error: logger.error }
-}

--- a/libs/api/solana/data-access/.babelrc
+++ b/libs/api/solana/data-access/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    [
+      "@nrwl/web/babel",
+      {
+        "useBuiltIns": "usage"
+      }
+    ]
+  ]
+}

--- a/libs/api/solana/data-access/.eslintrc.json
+++ b/libs/api/solana/data-access/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/api/solana/data-access/README.md
+++ b/libs/api/solana/data-access/README.md
@@ -1,0 +1,7 @@
+# api-solana-data-access
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test api-solana-data-access` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/api/solana/data-access/jest.config.ts
+++ b/libs/api/solana/data-access/jest.config.ts
@@ -1,0 +1,16 @@
+/* eslint-disable */
+export default {
+  displayName: 'api-solana-data-access',
+  preset: '../../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../../coverage/libs/api/solana/data-access',
+}

--- a/libs/api/solana/data-access/project.json
+++ b/libs/api/solana/data-access/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "api-solana-data-access",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/api/solana/data-access/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/api/solana/data-access/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/api/solana/data-access/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": ["scope:api", "type:data-access"]
+}

--- a/libs/api/solana/data-access/src/index.ts
+++ b/libs/api/solana/data-access/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/api-solana-data-access.service'
+export * from './lib/api-solana-data-access.module'

--- a/libs/api/solana/data-access/src/lib/api-solana-data-access.module.ts
+++ b/libs/api/solana/data-access/src/lib/api-solana-data-access.module.ts
@@ -1,0 +1,10 @@
+import { ApiCoreDataAccessModule } from '@kin-kinetic/api/core/data-access'
+import { Module } from '@nestjs/common'
+import { ApiSolanaDataAccessService } from './api-solana-data-access.service'
+
+@Module({
+  providers: [ApiSolanaDataAccessService],
+  exports: [ApiSolanaDataAccessService],
+  imports: [ApiCoreDataAccessModule],
+})
+export class ApiSolanaDataAccessModule {}

--- a/libs/api/solana/data-access/src/lib/api-solana-data-access.service.spec.ts
+++ b/libs/api/solana/data-access/src/lib/api-solana-data-access.service.spec.ts
@@ -1,0 +1,20 @@
+import { ApiCoreDataAccessModule } from '@kin-kinetic/api/core/data-access'
+import { Test } from '@nestjs/testing'
+import { ApiSolanaDataAccessService } from './api-solana-data-access.service'
+
+describe('ApiSolanaDataAccessService', () => {
+  let service: ApiSolanaDataAccessService
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [ApiCoreDataAccessModule],
+      providers: [ApiSolanaDataAccessService],
+    }).compile()
+
+    service = module.get(ApiSolanaDataAccessService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeTruthy()
+  })
+})

--- a/libs/api/solana/data-access/src/lib/api-solana-data-access.service.ts
+++ b/libs/api/solana/data-access/src/lib/api-solana-data-access.service.ts
@@ -1,0 +1,33 @@
+import { ApiCoreDataAccessService } from '@kin-kinetic/api/core/data-access'
+import { Solana } from '@kin-kinetic/solana'
+import { Injectable, Logger } from '@nestjs/common'
+
+@Injectable()
+export class ApiSolanaDataAccessService {
+  private readonly connections = new Map<string, Solana>()
+  private readonly loggers = new Map<string, Logger>()
+  constructor(private readonly data: ApiCoreDataAccessService) {}
+
+  deleteConnection(environment: string, index: number): void {
+    const appKey = this.data.getAppKey(environment, index)
+    this.connections.delete(appKey)
+    this.getLogger(appKey).log(`Deleted cached connection for ${appKey}`)
+  }
+
+  async getConnection(environment: string, index: number): Promise<Solana> {
+    const appKey = this.data.getAppKey(environment, index)
+    if (!this.connections.has(appKey)) {
+      const env = await this.data.getAppByEnvironmentIndex(environment, index)
+      this.connections.set(appKey, new Solana(env.cluster.endpointPrivate, { logger: this.getLogger(appKey) }))
+      this.getLogger(appKey).log(`Created new connection for ${appKey}`)
+    }
+    return this.connections.get(appKey)
+  }
+
+  private getLogger(appKey: string) {
+    if (!this.loggers.has(appKey)) {
+      this.loggers.set(appKey, new Logger(`${ApiSolanaDataAccessService.name}:${appKey}`))
+    }
+    return this.loggers.get(appKey)
+  }
+}

--- a/libs/api/solana/data-access/tsconfig.json
+++ b/libs/api/solana/data-access/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/api/solana/data-access/tsconfig.lib.json
+++ b/libs/api/solana/data-access/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "target": "es6"
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"]
+}

--- a/libs/api/solana/data-access/tsconfig.spec.json
+++ b/libs/api/solana/data-access/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/api/transaction/data-access/src/lib/api-transaction-data-access.module.ts
+++ b/libs/api/transaction/data-access/src/lib/api-transaction-data-access.module.ts
@@ -1,11 +1,12 @@
 import { ApiCoreDataAccessModule } from '@kin-kinetic/api/core/data-access'
+import { ApiSolanaDataAccessModule } from '@kin-kinetic/api/solana/data-access'
 import { ApiWebhookDataAccessModule } from '@kin-kinetic/api/webhook/data-access'
 import { Module } from '@nestjs/common'
 import { ApiTransactionDataAccessService } from './api-transaction-data-access.service'
 import { ApiTransactionUserDataAccessService } from './api-transaction-user-data-access.service'
 
 @Module({
-  imports: [ApiCoreDataAccessModule, ApiWebhookDataAccessModule],
+  imports: [ApiCoreDataAccessModule, ApiSolanaDataAccessModule, ApiWebhookDataAccessModule],
   providers: [ApiTransactionDataAccessService, ApiTransactionUserDataAccessService],
   exports: [ApiTransactionDataAccessService, ApiTransactionUserDataAccessService],
 })

--- a/libs/api/transaction/data-access/src/lib/api-transaction-data-access.service.spec.ts
+++ b/libs/api/transaction/data-access/src/lib/api-transaction-data-access.service.spec.ts
@@ -1,4 +1,5 @@
 import { ApiCoreDataAccessModule } from '@kin-kinetic/api/core/data-access'
+import { ApiSolanaDataAccessModule } from '@kin-kinetic/api/solana/data-access'
 import { ApiWebhookDataAccessModule } from '@kin-kinetic/api/webhook/data-access'
 import { Test } from '@nestjs/testing'
 import { ApiTransactionDataAccessService } from './api-transaction-data-access.service'
@@ -8,7 +9,7 @@ describe('ApiTransactionDataAccessService', () => {
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      imports: [ApiCoreDataAccessModule, ApiWebhookDataAccessModule],
+      imports: [ApiCoreDataAccessModule, ApiSolanaDataAccessModule, ApiWebhookDataAccessModule],
       providers: [ApiTransactionDataAccessService],
     }).compile()
 

--- a/libs/api/wallet/data-access/src/lib/api-wallet-data-access.module.ts
+++ b/libs/api/wallet/data-access/src/lib/api-wallet-data-access.module.ts
@@ -1,4 +1,5 @@
 import { ApiCoreDataAccessModule } from '@kin-kinetic/api/core/data-access'
+import { ApiSolanaDataAccessModule } from '@kin-kinetic/api/solana/data-access'
 import { ApiWebhookDataAccessModule } from '@kin-kinetic/api/webhook/data-access'
 import { Module } from '@nestjs/common'
 import { ApiWalletAdminDataAccessService } from './api-wallet-admin-data-access.service'
@@ -7,6 +8,6 @@ import { ApiWalletUserDataAccessService } from './api-wallet-user-data-access.se
 @Module({
   providers: [ApiWalletAdminDataAccessService, ApiWalletUserDataAccessService],
   exports: [ApiWalletAdminDataAccessService, ApiWalletUserDataAccessService],
-  imports: [ApiCoreDataAccessModule, ApiWebhookDataAccessModule],
+  imports: [ApiCoreDataAccessModule, ApiSolanaDataAccessModule, ApiWebhookDataAccessModule],
 })
 export class ApiWalletDataAccessModule {}

--- a/libs/api/wallet/data-access/src/lib/api-wallet-data-access.service.spec.ts
+++ b/libs/api/wallet/data-access/src/lib/api-wallet-data-access.service.spec.ts
@@ -1,4 +1,5 @@
 import { ApiCoreDataAccessModule } from '@kin-kinetic/api/core/data-access'
+import { ApiSolanaDataAccessModule } from '@kin-kinetic/api/solana/data-access'
 import { ApiWebhookDataAccessModule } from '@kin-kinetic/api/webhook/data-access'
 import { Test } from '@nestjs/testing'
 import { ApiWalletUserDataAccessService } from './api-wallet-user-data-access.service'
@@ -8,7 +9,7 @@ describe('ApiWalletDataAccessService', () => {
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      imports: [ApiCoreDataAccessModule, ApiWebhookDataAccessModule],
+      imports: [ApiCoreDataAccessModule, ApiSolanaDataAccessModule, ApiWebhookDataAccessModule],
       providers: [ApiWalletUserDataAccessService],
     }).compile()
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -38,6 +38,7 @@
       "@kin-kinetic/api/cron/data-access": ["libs/api/cron/data-access/src/index.ts"],
       "@kin-kinetic/api/queue/data-access": ["libs/api/queue/data-access/src/index.ts"],
       "@kin-kinetic/api/queue/feature": ["libs/api/queue/feature/src/index.ts"],
+      "@kin-kinetic/api/solana/data-access": ["libs/api/solana/data-access/src/index.ts"],
       "@kin-kinetic/api/transaction/data-access": ["libs/api/transaction/data-access/src/index.ts"],
       "@kin-kinetic/api/transaction/feature": ["libs/api/transaction/feature/src/index.ts"],
       "@kin-kinetic/api/user/data-access": ["libs/api/user/data-access/src/index.ts"],


### PR DESCRIPTION
There are a bunch of operations that fetch data from Solana that can be easily cached. In order to prepare for this, we'll add a new `ApiSolanaDataAccessService` that will handle all Solana connections for an appEnv, and we will add caching / metrics in there.

Doing it this way makes sure that the `Solana` class from `@kin-kinetic/solana` can stay clean and focused.   