### PR TITLE
refactor: use 'appKey' instead of 'environment, index' as app environment identifier

### DIFF
--- a/libs/api/account/feature/src/lib/api-account-feature.controller.ts
+++ b/libs/api/account/feature/src/lib/api-account-feature.controller.ts
@@ -6,7 +6,7 @@ import {
   CreateAccountRequest,
   HistoryResponse,
 } from '@kin-kinetic/api/account/data-access'
-import { PublicKeyPipe } from '@kin-kinetic/api/core/util'
+import { getAppKey, PublicKeyPipe } from '@kin-kinetic/api/core/util'
 import { Transaction } from '@kin-kinetic/api/transaction/data-access'
 import { Commitment } from '@kin-kinetic/solana'
 import { Body, Controller, Get, Param, ParseIntPipe, Post, Query, Req } from '@nestjs/common'
@@ -43,7 +43,7 @@ export class ApiAccountFeatureController {
     @Param('index', ParseIntPipe) index: number,
     @Param('accountId', new PublicKeyPipe('accountId')) accountId: string,
   ) {
-    return this.service.getAccountInfo(environment, index, accountId)
+    return this.service.getAccountInfo(getAppKey(environment, index), accountId)
   }
 
   @Get('balance/:environment/:index/:accountId')
@@ -57,7 +57,7 @@ export class ApiAccountFeatureController {
     @Param('accountId', new PublicKeyPipe('accountId')) accountId: string,
     @Query('commitment') commitment: Commitment,
   ) {
-    return this.service.getBalance(environment, index, accountId, commitment)
+    return this.service.getBalance(getAppKey(environment, index), accountId, commitment)
   }
 
   @Get('history/:environment/:index/:accountId/:mint')
@@ -70,7 +70,7 @@ export class ApiAccountFeatureController {
     @Param('accountId', new PublicKeyPipe('accountId')) accountId: string,
     @Param('mint', new PublicKeyPipe('mint')) mint: string,
   ) {
-    return this.service.getHistory(environment, index, accountId, mint)
+    return this.service.getHistory(getAppKey(environment, index), accountId, mint)
   }
 
   @Get('token-accounts/:environment/:index/:accountId/:mint')
@@ -83,6 +83,6 @@ export class ApiAccountFeatureController {
     @Param('accountId', new PublicKeyPipe('accountId')) accountId: string,
     @Param('mint', new PublicKeyPipe('mint')) mint: string,
   ) {
-    return this.service.getTokenAccounts(environment, index, accountId, mint)
+    return this.service.getTokenAccounts(getAppKey(environment, index), accountId, mint)
   }
 }

--- a/libs/api/airdrop/data-access/src/lib/api-airdrop-data-access.service.ts
+++ b/libs/api/airdrop/data-access/src/lib/api-airdrop-data-access.service.ts
@@ -1,5 +1,6 @@
 import { Airdrop } from '@kin-kinetic/api/airdrop/util'
 import { ApiCoreDataAccessService } from '@kin-kinetic/api/core/data-access'
+import { getAppKey } from '@kin-kinetic/api/core/util'
 import { ApiSolanaDataAccessService } from '@kin-kinetic/api/solana/data-access'
 import { Commitment } from '@kin-kinetic/solana'
 import { BadRequestException, Injectable, Logger } from '@nestjs/common'
@@ -13,15 +14,15 @@ export class ApiAirdropDataAccessService {
 
   constructor(private readonly data: ApiCoreDataAccessService, private readonly solana: ApiSolanaDataAccessService) {}
 
-  async requestAirdrop(request: RequestAirdropRequest): Promise<RequestAirdropResponse> {
-    const { environment, index } = request
-    const solana = await this.solana.getConnection(environment, index)
-    const appEnv = await this.data.getAppByEnvironmentIndex(environment, index)
+  async requestAirdrop(input: RequestAirdropRequest): Promise<RequestAirdropResponse> {
+    const appKey = getAppKey(input.environment, input.index)
+    const appEnv = await this.data.getAppEnvironmentByAppKey(appKey)
+    const solana = await this.solana.getConnection(appKey)
 
     // Make sure the requested mint is enabled for this app
-    const appMint = appEnv.mints.find((mint) => mint.mint.address === request.mint)
+    const appMint = appEnv.mints.find((mint) => mint.mint.address === input.mint)
     if (!appMint) {
-      throw new BadRequestException(`Can't find mint ${request.mint} in environment ${environment} for index ${index}`)
+      throw new BadRequestException(`Can't find mint ${input.mint} in app ${appKey}`)
     }
     const mint = appMint.mint
 
@@ -33,7 +34,7 @@ export class ApiAirdropDataAccessService {
 
     // Make sure there is an Airdrop configured with a Solana connection
     if (!this.airdrop.get(mint.id)) {
-      this.logger.verbose(`Creating airdrop for ${mint.symbol} (${mint.address}) on ${environment}`)
+      this.logger.verbose(`Creating airdrop for ${mint.symbol} (${mint.address}) in app ${appKey}`)
       this.airdrop.set(
         mint.id,
         new Airdrop({
@@ -44,10 +45,10 @@ export class ApiAirdropDataAccessService {
     }
 
     try {
-      const commitment = request.commitment || Commitment.Confirmed
-      const account = request.account
-      const amount = request.amount ? request.amount : 1
-      this.logger.verbose(`Requesting airdrop: ${account} ${amount} ${mint.symbol} (${mint.address}) on ${environment}`)
+      const commitment = input.commitment || Commitment.Confirmed
+      const account = input.account
+      const amount = input.amount ? input.amount : 1
+      this.logger.verbose(`Requesting airdrop: ${account} ${amount} ${mint.symbol} (${mint.address}) in app ${appKey}`)
       const result = await this.airdrop.get(mint.id).airdrop(account, amount, commitment)
 
       return {

--- a/libs/api/app/data-access/src/lib/api-app-data-access.service.ts
+++ b/libs/api/app/data-access/src/lib/api-app-data-access.service.ts
@@ -49,8 +49,8 @@ export class ApiAppDataAccessService implements OnModuleInit {
     })
   }
 
-  async getAppConfig(environment: string, index: number): Promise<AppConfig> {
-    const { appEnv, appKey } = await this.data.getAppEnvironment(environment, index)
+  async getAppConfig(appKey: string): Promise<AppConfig> {
+    const appEnv = await this.data.getAppEnvironmentByAppKey(appKey)
     if (!appEnv) {
       this.getAppConfigErrorCounter.add(1, { appKey })
       throw new NotFoundException(`App not found :(`)
@@ -99,9 +99,9 @@ export class ApiAppDataAccessService implements OnModuleInit {
     }
   }
 
-  async getAppHealth(environment: string, index: number): Promise<AppHealth> {
+  async getAppHealth(appKey: string): Promise<AppHealth> {
     const isKineticOk = true
-    const solana = await this.solana.getConnection(environment, index)
+    const solana = await this.solana.getConnection(appKey)
 
     const isSolanaOk = await solana.healthCheck()
 

--- a/libs/api/app/data-access/src/lib/api-app-env-user-data-access.service.ts
+++ b/libs/api/app/data-access/src/lib/api-app-env-user-data-access.service.ts
@@ -103,10 +103,6 @@ export class ApiAppEnvUserDataAccessService {
     return this.data.deleteAppEnv(appId, appEnvId)
   }
 
-  getAppKey(name: string, index: number) {
-    return this.data.getAppKey(name, index)
-  }
-
   getEndpoint() {
     return this.data.config.apiUrl?.replace('/api', '')
   }

--- a/libs/api/app/feature/src/lib/api-app-env-user-feature.resolver.ts
+++ b/libs/api/app/feature/src/lib/api-app-env-user-feature.resolver.ts
@@ -1,8 +1,9 @@
 import { ApiAppEnvUserDataAccessService, AppEnv, AppEnvStats } from '@kin-kinetic/api/app/data-access'
 import { ApiAuthGraphqlGuard, CtxUser } from '@kin-kinetic/api/auth/data-access'
+import { getAppKey } from '@kin-kinetic/api/core/util'
+import { TransactionStatus } from '@kin-kinetic/api/transaction/data-access'
 import { User } from '@kin-kinetic/api/user/data-access'
 import { Wallet } from '@kin-kinetic/api/wallet/data-access'
-import { TransactionStatus } from '@kin-kinetic/api/transaction/data-access'
 import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql'
 
@@ -76,7 +77,7 @@ export class ApiAppEnvUserFeatureResolver {
 
   @ResolveField(() => String, { nullable: true })
   key(@Parent() appEnv: AppEnv) {
-    return this.service.getAppKey(appEnv?.name, appEnv?.app?.index)
+    return getAppKey(appEnv?.name, appEnv?.app?.index)
   }
 
   @ResolveField(() => [Wallet], { nullable: true })

--- a/libs/api/app/feature/src/lib/api-app-feature.controller.ts
+++ b/libs/api/app/feature/src/lib/api-app-feature.controller.ts
@@ -1,4 +1,5 @@
 import { ApiAppDataAccessService, AppConfig, AppHealth } from '@kin-kinetic/api/app/data-access'
+import { getAppKey } from '@kin-kinetic/api/core/util'
 import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common'
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger'
 
@@ -12,7 +13,7 @@ export class ApiAppFeatureController {
   @ApiParam({ name: 'index', type: 'integer' })
   @ApiResponse({ type: AppConfig })
   app(@Param('environment') environment: string, @Param('index', ParseIntPipe) index: number) {
-    return this.service.getAppConfig(environment, index)
+    return this.service.getAppConfig(getAppKey(environment, index))
   }
 
   @Get(':environment/:index/health')
@@ -20,6 +21,6 @@ export class ApiAppFeatureController {
   @ApiParam({ name: 'index', type: 'integer' })
   @ApiResponse({ type: AppHealth })
   appHealth(@Param('environment') environment: string, @Param('index', ParseIntPipe) index: number) {
-    return this.service.getAppHealth(environment, index)
+    return this.service.getAppHealth(getAppKey(environment, index))
   }
 }

--- a/libs/api/cluster/data-access/src/lib/api-cluster-admin-data-access.service.ts
+++ b/libs/api/cluster/data-access/src/lib/api-cluster-admin-data-access.service.ts
@@ -1,4 +1,5 @@
 import { ApiCoreDataAccessService } from '@kin-kinetic/api/core/data-access'
+import { getAppKey } from '@kin-kinetic/api/core/util'
 import { ApiSolanaDataAccessService } from '@kin-kinetic/api/solana/data-access'
 import { Keypair } from '@kin-kinetic/keypair'
 import { BadRequestException, Injectable, Logger } from '@nestjs/common'
@@ -77,7 +78,7 @@ export class ApiClusterAdminDataAccessService {
       include: { app: true },
     })
     for (const env of envs) {
-      this.solana.deleteConnection(env.name, env.app.index)
+      this.solana.deleteConnection(getAppKey(env.name, env.app.index))
     }
     return updated
   }

--- a/libs/api/core/data-access/src/lib/api-core-data-access.service.ts
+++ b/libs/api/core/data-access/src/lib/api-core-data-access.service.ts
@@ -2,6 +2,7 @@ import { AirdropConfig } from '@kin-kinetic/api/airdrop/util'
 import { hashPassword } from '@kin-kinetic/api/auth/util'
 import { ProvisionedCluster } from '@kin-kinetic/api/cluster/util'
 import { ApiConfigDataAccessService } from '@kin-kinetic/api/config/data-access'
+import { parseAppKey } from '@kin-kinetic/api/core/util'
 import { Keypair } from '@kin-kinetic/keypair'
 import { getPublicKey } from '@kin-kinetic/solana'
 import { Injectable, Logger, NotFoundException, OnModuleInit, UnauthorizedException } from '@nestjs/common'
@@ -164,17 +165,8 @@ export class ApiCoreDataAccessService extends PrismaClient implements OnModuleIn
     })
   }
 
-  async getAppEnvironment(environment: string, index: number): Promise<{ appEnv: AppEnvironment; appKey: string }> {
-    const appEnv = await this.getAppByEnvironmentIndex(environment, index)
-    const appKey = this.getAppKey(environment, index)
-    return {
-      appEnv,
-      appKey,
-    }
-  }
-
-  getAppByEnvironmentIndex(environment: string, index: number): Promise<AppEnvironment> {
-    const appKey = this.getAppKey(environment, index)
+  getAppEnvironmentByAppKey(appKey: string): Promise<AppEnvironment> {
+    const { environment, index } = parseAppKey(appKey)
     this.getAppByEnvironmentIndexCounter?.add(1, { appKey })
     return this.appEnv.findFirst({
       where: { app: { index }, name: environment },
@@ -221,10 +213,6 @@ export class ApiCoreDataAccessService extends PrismaClient implements OnModuleIn
 
   getAppEnvById(appEnvId: string) {
     return this.appEnv.findUnique({ where: { id: appEnvId }, include: { app: true } })
-  }
-
-  getAppKey(environment: string, index: number): string {
-    return `app-${index}-${environment}`
   }
 
   async getUserByEmail(email: string) {

--- a/libs/api/core/util/src/index.ts
+++ b/libs/api/core/util/src/index.ts
@@ -1,2 +1,3 @@
+export * from './lib/get-parse-app-key'
 export * from './lib/open-telemetry-sdk'
 export * from './lib/public-key.pipe'

--- a/libs/api/core/util/src/lib/get-parse-app-key.ts
+++ b/libs/api/core/util/src/lib/get-parse-app-key.ts
@@ -1,0 +1,14 @@
+export const APP_KEY_PREFIX = 'app'
+
+// We use the 'appKey' to identify a specific app in a specific environment.
+// The appKey is a combination of the environment and the index of the app in that environment.
+// The appKey is used to identify the app in the database and in the cache and internal API requests.
+export function getAppKey(environment: string, index: number): string {
+  return `${APP_KEY_PREFIX}-${index}-${environment}`
+}
+
+export function parseAppKey(appKey: string): { environment: string; index: number } {
+  const [index, environment] = appKey.replace(`${APP_KEY_PREFIX}-`, '').split('-')
+
+  return { environment, index: Number(index) }
+}

--- a/libs/api/queue/data-access/src/lib/api-queue-data-access.service.ts
+++ b/libs/api/queue/data-access/src/lib/api-queue-data-access.service.ts
@@ -1,4 +1,5 @@
 import { ApiCoreDataAccessService } from '@kin-kinetic/api/core/data-access'
+import { getAppKey } from '@kin-kinetic/api/core/util'
 import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { AdminQueueLoadInput } from './dto/admin-queue-load.input'
 import { JobStatus } from './entity/job-status.enum'
@@ -97,6 +98,7 @@ export class ApiQueueDataAccessService {
   }
 
   async loadAccountQueue({ environment, index, payload }: AdminQueueLoadInput) {
+    const appKey = getAppKey(environment, index)
     const accounts = payload
       .toString()
       .split(/\r?\n/)
@@ -105,11 +107,8 @@ export class ApiQueueDataAccessService {
 
     const uniqueAccounts = [...new Set(accounts)]
 
-    this.logger.debug(
-      `Loading ${uniqueAccounts.length} accounts into ${QueueType.CloseAccount} ${environment}-${index} queue`,
-    )
-
-    const { appEnv } = await this.data.getAppEnvironment(environment, index)
+    this.logger.debug(`Loading ${uniqueAccounts.length} accounts into ${QueueType.CloseAccount} queue in app ${appKey}`)
+    const appEnv = await this.data.getAppEnvironmentByAppKey(appKey)
 
     // TODO: Add support for specifying which Mint accounts to close
     // Currently, only the token account for the default Mint is closed

--- a/libs/api/queue/data-access/src/lib/queue/close-account/api-queue-close-account.processor.ts
+++ b/libs/api/queue/data-access/src/lib/queue/close-account/api-queue-close-account.processor.ts
@@ -1,4 +1,5 @@
 import { validateCloseAccount } from '@kin-kinetic/api/account/data-access'
+import { getAppKey } from '@kin-kinetic/api/core/util'
 import { Commitment } from '@kin-kinetic/solana'
 import { Process, Processor } from '@nestjs/bull'
 import { Logger } from '@nestjs/common'
@@ -19,7 +20,8 @@ export class ApiQueueCloseAccountProcessor {
     this.logger.debug(`${job.id} Start processing...`)
 
     try {
-      const accountInfo = await this.service.account.getAccountInfo(environment, index, account)
+      const appKey = getAppKey(environment, index)
+      const accountInfo = await this.service.account.getAccountInfo(appKey, account)
 
       try {
         validateCloseAccount({ info: accountInfo, mint, mints, wallets })
@@ -28,7 +30,7 @@ export class ApiQueueCloseAccountProcessor {
           `${job.id} Account can close! ${JSON.stringify({ info: accountInfo, mint, mints, wallets }, null, 2)}`,
         )
 
-        const { appEnv, appKey } = await this.service.data.getAppEnvironment(environment, index)
+        const appEnv = await this.service.data.getAppEnvironmentByAppKey(appKey)
 
         const transaction = await this.service.account.handleCloseAccount(
           {

--- a/libs/api/solana/data-access/src/lib/api-solana-data-access.service.ts
+++ b/libs/api/solana/data-access/src/lib/api-solana-data-access.service.ts
@@ -8,17 +8,15 @@ export class ApiSolanaDataAccessService {
   private readonly loggers = new Map<string, Logger>()
   constructor(private readonly data: ApiCoreDataAccessService) {}
 
-  deleteConnection(environment: string, index: number): void {
-    const appKey = this.data.getAppKey(environment, index)
+  deleteConnection(appKey: string): void {
     this.connections.delete(appKey)
     this.getLogger(appKey).log(`Deleted cached connection for ${appKey}`)
   }
 
-  async getConnection(environment: string, index: number): Promise<Solana> {
-    const appKey = this.data.getAppKey(environment, index)
+  async getConnection(appKey: string): Promise<Solana> {
     if (!this.connections.has(appKey)) {
-      const env = await this.data.getAppByEnvironmentIndex(environment, index)
-      this.connections.set(appKey, new Solana(env.cluster.endpointPrivate, { logger: this.getLogger(appKey) }))
+      const appEnv = await this.data.getAppEnvironmentByAppKey(appKey)
+      this.connections.set(appKey, new Solana(appEnv.cluster.endpointPrivate, { logger: this.getLogger(appKey) }))
       this.getLogger(appKey).log(`Created new connection for ${appKey}`)
     }
     return this.connections.get(appKey)

--- a/libs/api/transaction/feature/src/lib/api-transaction-feature.controller.ts
+++ b/libs/api/transaction/feature/src/lib/api-transaction-feature.controller.ts
@@ -1,3 +1,4 @@
+import { getAppKey } from '@kin-kinetic/api/core/util'
 import {
   ApiTransactionDataAccessService,
   GetTransactionResponse,
@@ -21,7 +22,7 @@ export class ApiTransactionFeatureController {
   @ApiParam({ name: 'index', type: 'integer' })
   @ApiResponse({ type: LatestBlockhashResponse })
   getLatestBlockhash(@Param('environment') environment: string, @Param('index', ParseIntPipe) index: number) {
-    return this.service.getLatestBlockhash(environment, index)
+    return this.service.getLatestBlockhash(getAppKey(environment, index))
   }
 
   @Get('minimum-rent-exemption-balance/:environment/:index')
@@ -33,7 +34,7 @@ export class ApiTransactionFeatureController {
     @Param('index', ParseIntPipe) index: number,
     @Param('input') input: MinimumRentExemptionBalanceRequest,
   ) {
-    return this.service.getMinimumRentExemptionBalance(environment, index, input)
+    return this.service.getMinimumRentExemptionBalance(getAppKey(environment, index), input)
   }
 
   @Post('make-transfer')
@@ -53,6 +54,6 @@ export class ApiTransactionFeatureController {
     @Param('index', ParseIntPipe) index: number,
     @Param('signature') signature: string,
   ) {
-    return this.service.getTransaction(environment, index, signature)
+    return this.service.getTransaction(getAppKey(environment, index), signature)
   }
 }

--- a/libs/api/webhook/data-access/src/lib/api-webhook-data-access.service.ts
+++ b/libs/api/webhook/data-access/src/lib/api-webhook-data-access.service.ts
@@ -1,4 +1,5 @@
 import { ApiCoreDataAccessService } from '@kin-kinetic/api/core/data-access'
+import { getAppKey } from '@kin-kinetic/api/core/util'
 import { HttpService } from '@nestjs/axios'
 import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common'
 import { App, AppEnv, Transaction, WalletBalance, WebhookDirection, WebhookType } from '@prisma/client'
@@ -26,7 +27,7 @@ export class ApiWebhookDataAccessService {
   constructor(private readonly data: ApiCoreDataAccessService, private readonly http: HttpService) {}
 
   sendWebhook(appEnv: AppEnv & { app: App }, options: WebhookOptions) {
-    const appKey = this.data.getAppKey(appEnv.name, appEnv.app?.index)
+    const appKey = getAppKey(appEnv.name, appEnv.app?.index)
     switch (options.type) {
       case WebhookType.Balance:
         if (!appEnv.webhookDebugging) {
@@ -70,8 +71,7 @@ export class ApiWebhookDataAccessService {
   }
 
   async storeIncomingWebhook(
-    environment: string,
-    index: number,
+    appKey: string,
     type: string,
     headers: IncomingHttpHeaders,
     payload: object,
@@ -85,7 +85,7 @@ export class ApiWebhookDataAccessService {
 
     try {
       // Get the app by Index
-      const appEnv = await this.data.getAppByEnvironmentIndex(environment, index)
+      const appEnv = await this.data.getAppEnvironmentByAppKey(appKey)
       if (!appEnv.webhookDebugging) {
         this.logger.warn(`storeIncomingWebhook ignoring request, webhookDebugging is disabled`)
         res.statusCode = 400

--- a/libs/api/webhook/feature/src/lib/api-webhook-feature.controller.ts
+++ b/libs/api/webhook/feature/src/lib/api-webhook-feature.controller.ts
@@ -1,3 +1,4 @@
+import { getAppKey } from '@kin-kinetic/api/core/util'
 import { ApiWebhookDataAccessService } from '@kin-kinetic/api/webhook/data-access'
 import { Controller, Param, ParseIntPipe, Post, Req, Res } from '@nestjs/common'
 import { ApiExcludeEndpoint } from '@nestjs/swagger'
@@ -16,6 +17,6 @@ export class ApiWebhookFeatureController {
     @Param('index', ParseIntPipe) index: number,
     @Param('type') type: string,
   ) {
-    return this.service.storeIncomingWebhook(environment, index, type, req.headers, req.body, res)
+    return this.service.storeIncomingWebhook(getAppKey(environment, index), type, req.headers, req.body, res)
   }
 }


### PR DESCRIPTION
This PR refactors the usage of 2 parameters (`environment: string` + `index: number`) to identify an app, to a composite key: `app-${environment}-${index}` and adds some helper functions to do this conversion.

At first glance it seems like a minor thing, but it makes things like caching easier (like in `ApiSolanaDataAccessService`) and will make #419 easier to implement.