### PR TITLE
feat: add cache to solana.getLatestBlockhash method

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ AUTH_USERS="alice|Kinetic@alice1|Admin|alice@email.com|http://avatars.dicebear.c
 APP_1_FEE_PAYER_SECRET=UvfuF3FPqLyvS8xGjSu4AUfdsY5QvLdnin8SKBLAi3UqgbmEWCDshPY3UcxvBgRAqHLzh5Ni1eypLVZArsis6FF
 APP_1_NAME="App 1"
 #APP_1_LOGO_URL=""
+# Cache configurations, all TTL values are in seconds
+#CACHE_SOLANA_GET_LATEST_BLOCKHASH_TTL=5
 #COOKIE_DOMAINS="localhost,local.kinetic.host,pages.dev"
 #COOKIE_NAME="__session"
 # If you want to configure CORS, define a comma-separated list of urls here.

--- a/libs/api/config/data-access/src/lib/api-config-data-access.service.ts
+++ b/libs/api/config/data-access/src/lib/api-config-data-access.service.ts
@@ -67,6 +67,16 @@ export class ApiConfigDataAccessService {
     return this.config.get('api.version')
   }
 
+  get cache(): { [key: string]: { [key: string]: { ttl: number } } } {
+    return {
+      solana: {
+        getLatestBlockhash: {
+          ttl: this.config.get('cache.solana.getLatestBlockhash.ttl'),
+        },
+      },
+    }
+  }
+
   get cookieDomains(): string[] {
     return this.config.get('cookie.domains')
   }

--- a/libs/api/config/feature/src/lib/config/configuration.ts
+++ b/libs/api/config/feature/src/lib/config/configuration.ts
@@ -30,6 +30,13 @@ export default () => ({
     passwordEnabled: process.env.AUTH_PASSWORD_ENABLED?.toLowerCase() !== 'false',
     users: process.env.AUTH_USERS || '',
   },
+  cache: {
+    solana: {
+      getLatestBlockhash: {
+        ttl: process.env.CACHE_SOLANA_GET_LATEST_BLOCKHASH_TTL,
+      },
+    },
+  },
   cors: {
     bypass: !origins.length,
     origins,

--- a/libs/api/config/feature/src/lib/config/validation-schema.ts
+++ b/libs/api/config/feature/src/lib/config/validation-schema.ts
@@ -4,6 +4,7 @@ export const validationSchema = Joi.object({
   API_URL: Joi.string().required().error(new Error(`API_URL is required.`)),
   AUTH_PASSWORD_ENABLED: Joi.boolean().default('false'),
   AUTH_USERS: Joi.string().default(''),
+  CACHE_SOLANA_GET_LATEST_BLOCKHASH_TTL: Joi.number().default(5),
   COOKIE_NAME: Joi.string().default('__session'),
   DATABASE_URL: Joi.string().required(),
   DISCORD_ENABLED: Joi.boolean().default('false'),

--- a/libs/api/solana/data-access/src/lib/api-solana-data-access.service.ts
+++ b/libs/api/solana/data-access/src/lib/api-solana-data-access.service.ts
@@ -1,5 +1,5 @@
 import { ApiCoreDataAccessService } from '@kin-kinetic/api/core/data-access'
-import { Solana } from '@kin-kinetic/solana'
+import { Solana, SolanaLogger } from '@kin-kinetic/solana'
 import { Injectable, Logger } from '@nestjs/common'
 
 @Injectable()
@@ -10,14 +10,14 @@ export class ApiSolanaDataAccessService {
 
   deleteConnection(appKey: string): void {
     this.connections.delete(appKey)
-    this.getLogger(appKey).log(`Deleted cached connection for ${appKey}`)
+    this.getLogger(appKey).verbose(`Deleted cached connection for ${appKey}`)
   }
 
   async getConnection(appKey: string): Promise<Solana> {
     if (!this.connections.has(appKey)) {
       const appEnv = await this.data.getAppEnvironmentByAppKey(appKey)
-      this.connections.set(appKey, new Solana(appEnv.cluster.endpointPrivate, { logger: this.getLogger(appKey) }))
-      this.getLogger(appKey).log(`Created new connection for ${appKey}`)
+      this.connections.set(appKey, new Solana(appEnv.cluster.endpointPrivate, { logger: this.getSolanaLogger(appKey) }))
+      this.getLogger(appKey).verbose(`Created new connection for ${appKey}`)
     }
     return this.connections.get(appKey)
   }
@@ -27,5 +27,14 @@ export class ApiSolanaDataAccessService {
       this.loggers.set(appKey, new Logger(`${ApiSolanaDataAccessService.name}:${appKey}`))
     }
     return this.loggers.get(appKey)
+  }
+
+  private getSolanaLogger(appKey: string): SolanaLogger {
+    const logger = this.getLogger(appKey)
+    return {
+      error: (message: string) => logger.error(message),
+      // The Solana class is pretty verbose so we only log the messages if the log level is set to debug
+      log: (message: string) => logger.debug(message),
+    }
   }
 }

--- a/libs/api/transaction/data-access/src/lib/api-transaction-data-access.service.ts
+++ b/libs/api/transaction/data-access/src/lib/api-transaction-data-access.service.ts
@@ -142,9 +142,12 @@ export class ApiTransactionDataAccessService implements OnModuleInit {
   }
 
   async getLatestBlockhash(appKey: string): Promise<LatestBlockhashResponse> {
-    const solana = await this.solana.getConnection(appKey)
-
-    return solana.getLatestBlockhash()
+    return this.data.cache.wrap<LatestBlockhashResponse>(
+      'solana',
+      `${appKey}:getLatestBlockhash`,
+      () => this.solana.getConnection(appKey).then((solana) => solana.getLatestBlockhash()),
+      this.data.config.cache.solana.getLatestBlockhash.ttl,
+    )
   }
 
   async getMinimumRentExemptionBalance(

--- a/libs/web/app/feature/src/lib/web-transaction-detail.tsx
+++ b/libs/web/app/feature/src/lib/web-transaction-detail.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Code, Flex, Icon, Stack, useDisclosure, useToast } from '@chakra-ui/react'
+import { Box, Button, Code, Flex, Icon, Stack, Text, useDisclosure, useToast } from '@chakra-ui/react'
 import { WebUiPropertyList } from '@kin-kinetic/web/app/ui'
 import { AppEnv, Transaction } from '@kin-kinetic/web/util/sdk'
 import { ButtonGroup } from '@saas-ui/react'
@@ -6,6 +6,7 @@ import { IconCopy } from '@tabler/icons'
 import { ReactNode } from 'react'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { MdError } from 'react-icons/md'
+import Timeago from 'react-timeago'
 import { WebTransactionTimeline } from './web-transaction-timeline'
 
 function Copy({ value, label }: { value: string; label?: ReactNode }) {
@@ -45,6 +46,8 @@ export function WebTransactionDetail({ env, transaction }: { env: AppEnv; transa
       <Box p="6" borderWidth="1px" borderRadius="lg">
         <WebUiPropertyList
           items={[
+            { label: 'Created', value: <Timestamp timestamp={transaction.createdAt} /> },
+            { label: 'Updated', value: <Timestamp timestamp={transaction.updatedAt} /> },
             { label: 'Status', value: transaction.status ? transaction.status : 'N/A' },
             { label: 'IP', value: `${transaction?.ip}` },
             { label: 'User Agent', value: `${transaction?.ua}` },
@@ -107,5 +110,14 @@ export function WebTransactionDetail({ env, transaction }: { env: AppEnv; transa
         )}
       </Box>
     </Stack>
+  )
+}
+
+export function Timestamp({ timestamp }: { timestamp: string }) {
+  return (
+    <Flex>
+      <Text mr={2}> {new Date(timestamp).toLocaleString()}</Text>
+      <Timeago date={timestamp} />
+    </Flex>
   )
 }


### PR DESCRIPTION
This PR adds a configurable cache to the `getLatestBlockhash` method. It can be configured using the `CACHE_SOLANA_GET_LATEST_BLOCKHASH_TTL` env var and it defaults to `5` seconds. According to [this documentation](https://docs.solana.com/implemented-proposals/durable-tx-nonces#problem) it could be valid up to 2 minutes.  