### PR TITLE
feat: add APP_1_ENABLE_WEBHOOKS env var to provision webhooks in debug mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ AUTH_USERS="alice|Kinetic@alice1|Admin|alice@email.com|http://avatars.dicebear.c
 APP_1_FEE_PAYER_SECRET=UvfuF3FPqLyvS8xGjSu4AUfdsY5QvLdnin8SKBLAi3UqgbmEWCDshPY3UcxvBgRAqHLzh5Ni1eypLVZArsis6FF
 APP_1_NAME="App 1"
 #APP_1_LOGO_URL=""
+# Enabling the webhooks will enable the event and verify webhooks in debug mode.
+#APP_1_ENABLE_WEBHOOKS=true
 # Cache configurations, all TTL values are in seconds
 #CACHE_SOLANA_GET_LATEST_BLOCKHASH_TTL=5
 #COOKIE_DOMAINS="localhost,local.kinetic.host,pages.dev"

--- a/api-schema.graphql
+++ b/api-schema.graphql
@@ -3,6 +3,7 @@
 # ------------------------------------------------------
 
 input AdminAppCreateInput {
+  enableWebhooks: Boolean
   index: Int!
   logoUrl: String
   name: String!

--- a/apps/api-e2e/src/generated/api-sdk.ts
+++ b/apps/api-e2e/src/generated/api-sdk.ts
@@ -21,6 +21,7 @@ export type Scalars = {
 }
 
 export type AdminAppCreateInput = {
+  enableWebhooks?: InputMaybe<Scalars['Boolean']>
   index: Scalars['Int']
   logoUrl?: InputMaybe<Scalars['String']>
   name: Scalars['String']

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -15,6 +15,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "enableWebhooks",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "index",
             "description": null,
             "type": {

--- a/libs/api/app/data-access/src/lib/dto/admin-app-create.input.ts
+++ b/libs/api/app/data-access/src/lib/dto/admin-app-create.input.ts
@@ -2,6 +2,9 @@ import { Field, InputType, Int } from '@nestjs/graphql'
 
 @InputType()
 export class AdminAppCreateInput {
+  @Field({ nullable: true })
+  enableWebhooks?: boolean
+
   @Field(() => Int)
   index: number
 

--- a/libs/api/config/data-access/src/lib/entity/provisioned-app.entity.ts
+++ b/libs/api/config/data-access/src/lib/entity/provisioned-app.entity.ts
@@ -1,6 +1,7 @@
 export interface ProvisionedApp {
-  secret: string
+  enableWebhooks: boolean
   index: number
   logoUrl?: string
   name: string
+  secret: string
 }

--- a/libs/api/config/data-access/src/lib/helpers/get-provisioned-apps.ts
+++ b/libs/api/config/data-access/src/lib/helpers/get-provisioned-apps.ts
@@ -16,5 +16,8 @@ export function getProvisionedApps(envVars: string[]): ProvisionedApp[] {
     index,
     name: process.env[`APP_${index}_NAME`],
     logoUrl: process.env[`APP_${index}_LOGO_URL`],
+    enableWebhooks: process.env[`APP_${index}_ENABLE_WEBHOOKS`]
+      ? process.env[`APP_${index}_ENABLE_WEBHOOKS`].toString().toLowerCase() === 'true'
+      : false,
   }))
 }

--- a/libs/web/util/sdk/src/generated/graphql.tsx
+++ b/libs/web/util/sdk/src/generated/graphql.tsx
@@ -23,6 +23,7 @@ export type Scalars = {
 }
 
 export type AdminAppCreateInput = {
+  enableWebhooks?: InputMaybe<Scalars['Boolean']>
   index: Scalars['Int']
   logoUrl?: InputMaybe<Scalars['String']>
   name: Scalars['String']


### PR DESCRIPTION
This PR adds support for an optional environment variable that can be used to provision your app. I will set up the webhooks in debug mode.

For most apps this won't be super useful, but we need it so we can set this up in our CI environment and run tests against it. 