### PR TITLE
feat: allow setting default commitment with KineticSdk config

### DIFF
--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -8,6 +8,7 @@ export type {
   AppConfigMint,
   BalanceResponse,
   BalanceToken,
+  Commitment,
   GetTransactionResponse,
   HistoryResponse,
   RequestAirdropResponse,

--- a/libs/sdk/src/lib/helpers/validate-kinetic-sdk-config.ts
+++ b/libs/sdk/src/lib/helpers/validate-kinetic-sdk-config.ts
@@ -1,3 +1,4 @@
+import { Commitment } from '@kin-kinetic/solana'
 import { KineticSdkConfig } from '../interfaces'
 
 function removeTrailingSlash(str: string) {
@@ -27,6 +28,7 @@ export function validateKineticSdkConfig(config: KineticSdkConfig): KineticSdkCo
   }
   return {
     ...config,
+    commitment: config.commitment || Commitment.Confirmed,
     endpoint: removeTrailingSlash(config.endpoint),
   }
 }

--- a/libs/sdk/src/lib/helpers/validate-kinetic-sdk-config.ts
+++ b/libs/sdk/src/lib/helpers/validate-kinetic-sdk-config.ts
@@ -1,4 +1,4 @@
-import { Commitment } from '@kin-kinetic/solana'
+import { Commitment } from '../../generated'
 import { KineticSdkConfig } from '../interfaces'
 
 function removeTrailingSlash(str: string) {

--- a/libs/sdk/src/lib/interfaces/close-account-options.ts
+++ b/libs/sdk/src/lib/interfaces/close-account-options.ts
@@ -1,4 +1,5 @@
-import { Commitment, PublicKeyString } from '@kin-kinetic/solana'
+import { PublicKeyString } from '@kin-kinetic/solana'
+import { Commitment } from '../../generated'
 
 export interface CloseAccountOptions {
   commitment?: Commitment

--- a/libs/sdk/src/lib/interfaces/create-account-options.ts
+++ b/libs/sdk/src/lib/interfaces/create-account-options.ts
@@ -1,5 +1,5 @@
 import { Keypair } from '@kin-kinetic/keypair'
-import { Commitment } from '@kin-kinetic/solana'
+import { Commitment } from '../../generated'
 
 export interface CreateAccountOptions {
   commitment?: Commitment

--- a/libs/sdk/src/lib/interfaces/get-account-info-options.ts
+++ b/libs/sdk/src/lib/interfaces/get-account-info-options.ts
@@ -1,5 +1,7 @@
 import { PublicKeyString } from '@kin-kinetic/solana'
+import { Commitment } from '../../generated'
 
 export interface GetAccountInfoOptions {
   account: PublicKeyString
+  commitment?: Commitment
 }

--- a/libs/sdk/src/lib/interfaces/get-balance-options.ts
+++ b/libs/sdk/src/lib/interfaces/get-balance-options.ts
@@ -1,4 +1,5 @@
-import { Commitment, PublicKeyString } from '@kin-kinetic/solana'
+import { PublicKeyString } from '@kin-kinetic/solana'
+import { Commitment } from '../../generated'
 
 export interface GetBalanceOptions {
   account: PublicKeyString

--- a/libs/sdk/src/lib/interfaces/kinetic-sdk-config.ts
+++ b/libs/sdk/src/lib/interfaces/kinetic-sdk-config.ts
@@ -1,6 +1,8 @@
+import { Commitment } from '@kin-kinetic/solana'
 import { KineticSdkLogger } from './kinetic-sdk-logger'
 
 export interface KineticSdkConfig {
+  commitment?: Commitment
   endpoint: string
   environment: string
   headers?: Record<string, string>

--- a/libs/sdk/src/lib/interfaces/kinetic-sdk-config.ts
+++ b/libs/sdk/src/lib/interfaces/kinetic-sdk-config.ts
@@ -1,4 +1,4 @@
-import { Commitment } from '@kin-kinetic/solana'
+import { Commitment } from '../../generated'
 import { KineticSdkLogger } from './kinetic-sdk-logger'
 
 export interface KineticSdkConfig {

--- a/libs/sdk/src/lib/interfaces/make-transfer-options.ts
+++ b/libs/sdk/src/lib/interfaces/make-transfer-options.ts
@@ -1,5 +1,6 @@
 import { Keypair } from '@kin-kinetic/keypair'
-import { Commitment, TransactionType } from '@kin-kinetic/solana'
+import { TransactionType } from '@kin-kinetic/solana'
+import { Commitment } from '../../generated'
 import { TransferDestination } from './transfer-destination'
 
 export interface MakeTransferOptions extends TransferDestination {

--- a/libs/sdk/src/lib/interfaces/request-airdrop-options.ts
+++ b/libs/sdk/src/lib/interfaces/request-airdrop-options.ts
@@ -1,4 +1,5 @@
-import { Commitment, PublicKeyString } from '@kin-kinetic/solana'
+import { PublicKeyString } from '@kin-kinetic/solana'
+import { Commitment } from '../../generated'
 
 export interface RequestAirdropOptions {
   account: PublicKeyString

--- a/libs/sdk/src/lib/kinetic-sdk-internal.ts
+++ b/libs/sdk/src/lib/kinetic-sdk-internal.ts
@@ -1,5 +1,4 @@
 import {
-  Commitment,
   generateCreateAccountTransaction,
   generateMakeTransferBatchTransaction,
   generateMakeTransferTransaction,
@@ -15,6 +14,7 @@ import {
   AppConfigMint,
   BalanceResponse,
   CloseAccountRequest,
+  Commitment,
   Configuration,
   CreateAccountRequest,
   HistoryResponse,

--- a/libs/sdk/src/lib/kinetic-sdk.spec.ts
+++ b/libs/sdk/src/lib/kinetic-sdk.spec.ts
@@ -1,6 +1,6 @@
 import { Keypair } from '@kin-kinetic/keypair'
-import { Commitment } from '@kin-kinetic/solana'
 import { clusterApiUrl } from '@solana/web3.js'
+import { Commitment } from '../generated'
 import { validateKineticSdkConfig } from './helpers/validate-kinetic-sdk-config'
 import { KineticSdkConfig } from './interfaces'
 import { KineticSdk } from './kinetic-sdk'


### PR DESCRIPTION
This PR adds the `commitment` property to the `KineticSdkConfig` interface that can be used to set the default commitment for the SDK.

The default commitment for all operations is now `Confirmed`.