### PR TITLE
fix: make sure to correctly show balance in Wallet screen

### DIFF
--- a/libs/web/admin/ui/src/lib/web-admin-ui-wallet-table.tsx
+++ b/libs/web/admin/ui/src/lib/web-admin-ui-wallet-table.tsx
@@ -40,7 +40,7 @@ export function WebAdminUiWalletTable({ wallets }: { wallets: Wallet[] }) {
                 {!Array.isArray(value) || !value?.length ? (
                   'Unknown'
                 ) : (
-                  <ShowSolBalance balance={value[0].balance || 0} />
+                  <ShowSolBalance balance={value[0].balance ?? 0} />
                 )}
               </Flex>
             )

--- a/libs/web/app/ui/src/lib/web-app-ui-wallet.tsx
+++ b/libs/web/app/ui/src/lib/web-app-ui-wallet.tsx
@@ -69,7 +69,7 @@ export function WebAppUiWallet({ appEnvId, appId, explorerUrl, wallet }: WebAppU
               <WebUiCopy size={'xs'} text={wallet.publicKey ?? ''} />
             </Stack>
             <Box fontWeight="semibold" fontSize="lg" lineHeight="tight" noOfLines={1}>
-              <ShowSolBalance balance={data?.balance?.balance} />
+              <ShowSolBalance balance={data?.balance?.balance ?? 0} />
             </Box>
           </Stack>
         </Stack>
@@ -146,6 +146,6 @@ export function WebAppUiWallet({ appEnvId, appId, explorerUrl, wallet }: WebAppU
  */
 export const LAMPORTS_PER_SOL = 1000000000
 
-export function ShowSolBalance({ balance }: { balance?: number | null | undefined }) {
+export function ShowSolBalance({ balance }: { balance: number }) {
   return <span>{balance ? balance / LAMPORTS_PER_SOL : 0} SOL</span>
 }


### PR DESCRIPTION
This fixes an issue where low balances like `0.009...` were displayed as `0`