### PR TITLE
refactor: use getAccountInfo to fetch token accounts on makeTransfer

### DIFF
--- a/apps/sdk-e2e/src/integration/account-kinetic-sdk-e2e.spec.ts
+++ b/apps/sdk-e2e/src/integration/account-kinetic-sdk-e2e.spec.ts
@@ -129,11 +129,12 @@ describe('KineticSdk (e2e) - Account', () => {
       // Create new account
       const keypair = Keypair.random()
       const tx = await sdk.createAccount({ owner: keypair, commitment: Commitment.Finalized })
+      expect(tx.errors).toEqual([])
       expect(tx).not.toBeNull()
       expect(tx.mint).toEqual(DEFAULT_MINT)
       const { signature, errors } = tx
-      expect(typeof signature).toBe('string')
       expect(errors).toEqual([])
+      expect(typeof signature).toBe('string')
       // Close account
       const closeTx = await sdk.closeAccount({ account: keypair.publicKey })
       expect(closeTx).not.toBeNull()
@@ -180,11 +181,12 @@ describe('KineticSdk (e2e) - Account', () => {
       // Create new account
       const keypair = Keypair.random()
       const tx = await sdk.createAccount({ owner: keypair, commitment: Commitment.Finalized })
+      expect(tx.errors).toEqual([])
       expect(tx).not.toBeNull()
       expect(tx.mint).toEqual(DEFAULT_MINT)
       const { signature, errors } = tx
-      expect(typeof signature).toBe('string')
       expect(errors).toEqual([])
+      expect(typeof signature).toBe('string')
 
       const airdrop = await sdk.requestAirdrop({
         account: keypair.publicKey,

--- a/apps/sdk-e2e/src/integration/transaction-kinetic-sdk-e2e.spec.ts
+++ b/apps/sdk-e2e/src/integration/transaction-kinetic-sdk-e2e.spec.ts
@@ -17,8 +17,8 @@ describe('KineticSdk (e2e)', () => {
     expect(tx).not.toBeNull()
     expect(tx.mint).toEqual(DEFAULT_MINT)
     const { signature, errors, amount, decimals, source } = tx
-    expect(typeof signature).toBe('string')
     expect(errors).toEqual([])
+    expect(typeof signature).toBe('string')
     expect(amount).toBe('43')
     expect(decimals).toBe(5)
     expect(source).toBe(aliceKeypair.publicKey)
@@ -29,11 +29,19 @@ describe('KineticSdk (e2e)', () => {
     expect(tx).not.toBeNull()
     expect(tx.mint).toEqual(DEFAULT_MINT)
     const { signature, errors, amount, decimals, source } = tx
-    expect(typeof signature).toBe('string')
     expect(errors).toEqual([])
+    expect(typeof signature).toBe('string')
     expect(amount).toBe('43.12345')
     expect(decimals).toBe(5)
     expect(source).toBe(aliceKeypair.publicKey)
+  })
+
+  it('should fail to make a transfer with a new account', async () => {
+    const kp = Keypair.random()
+
+    await expect(
+      async () => await sdk.makeTransfer({ amount: '43.12345', destination: bobKeypair.publicKey, owner: kp }),
+    ).rejects.toThrow(`Owner account doesn't exist for mint ${DEFAULT_MINT}`)
   })
 
   it('should make a transfer in batch', async () => {
@@ -47,8 +55,8 @@ describe('KineticSdk (e2e)', () => {
     expect(tx).not.toBeNull()
     expect(tx.mint).toEqual(DEFAULT_MINT)
     const { signature, errors, amount, decimals, source } = tx
-    expect(typeof signature).toBe('string')
     expect(errors).toEqual([])
+    expect(typeof signature).toBe('string')
     expect(amount).toBe('51')
     expect(decimals).toBe(5)
     expect(source).toBe(aliceKeypair.publicKey)
@@ -130,8 +138,8 @@ describe('KineticSdk (e2e)', () => {
     })
     expect(tx).not.toBeNull()
     const { signature, errors, amount, decimals, source } = tx
-    expect(typeof signature).toBe('string')
     expect(errors).toEqual([])
+    expect(typeof signature).toBe('string')
     expect(amount).toBe('43')
     expect(decimals).toBe(5)
     expect(source).toBe(aliceKeypair.publicKey)
@@ -147,7 +155,7 @@ describe('KineticSdk (e2e)', () => {
           owner: aliceKeypair,
           senderCreate: false,
         }),
-    ).rejects.toThrow(`Destination account doesn't exist.`)
+    ).rejects.toThrow(`Destination account doesn't exist for mint ${DEFAULT_MINT}.`)
   })
 
   it('should not allow transfers to a mint', async () => {
@@ -160,7 +168,7 @@ describe('KineticSdk (e2e)', () => {
           owner: aliceKeypair,
           senderCreate: false,
         }),
-    ).rejects.toThrow('Transfers to a mint are not allowed.')
+    ).rejects.toThrow('Account is a mint account.')
   })
 
   it('should not allow transfers to a mint in batch transfer', async () => {
@@ -185,8 +193,8 @@ describe('KineticSdk (e2e)', () => {
     expect(tx).not.toBeNull()
     expect(tx.mint).toBe(usdcMint)
     const { signature, errors, amount, decimals, source } = tx
-    expect(typeof signature).toBe('string')
     expect(errors).toEqual([])
+    expect(typeof signature).toBe('string')
     expect(amount).toBe('1.75')
     expect(decimals).toBe(2)
     expect(source).toBe(aliceKeypair.publicKey)
@@ -201,8 +209,8 @@ describe('KineticSdk (e2e)', () => {
     expect(tx).not.toBeNull()
     expect(usdcMint).toContain(tx.mint)
     const { signature, errors, amount, decimals, source } = tx
-    expect(typeof signature).toBe('string')
     expect(errors).toEqual([])
+    expect(typeof signature).toBe('string')
     expect(amount).toBe('2.22')
     expect(decimals).toBe(2)
     expect(source).toBe(aliceKeypair.publicKey)

--- a/libs/sdk/src/lib/helpers/get-token-address.ts
+++ b/libs/sdk/src/lib/helpers/get-token-address.ts
@@ -1,0 +1,8 @@
+import { getPublicKey } from '@kin-kinetic/solana'
+import { getAssociatedTokenAddress } from '@solana/spl-token'
+
+export async function getTokenAddress({ account, mint }: { account: string; mint: string }): Promise<string> {
+  const address = await getAssociatedTokenAddress(getPublicKey(mint), getPublicKey(account))
+
+  return address.toString()
+}

--- a/libs/sdk/src/lib/helpers/index.ts
+++ b/libs/sdk/src/lib/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './get-solana-rpc-endpoint'
+export * from './get-token-address'
 export * from './kin-to-quarks'

--- a/libs/solana/src/lib/interfaces/generate-make-transfer-transaction-options.ts
+++ b/libs/solana/src/lib/interfaces/generate-make-transfer-transaction-options.ts
@@ -7,12 +7,14 @@ export interface GenerateMakeTransferOptions {
   amount: string
   blockhash: string
   destination: PublicKeyString
+  destinationTokenAccount: PublicKeyString
   index: number
   lastValidBlockHeight: number
   mintDecimals: number
   mintFeePayer: PublicKeyString
   mintPublicKey: PublicKeyString
   owner: Keypair
+  ownerTokenAccount: PublicKeyString
   senderCreate?: boolean
   type: TransactionType
 }


### PR DESCRIPTION
This PR changes how `makeTransfer` fetches the addresses of the token accounts for both the owner and destination.

Previously, it used `getAssociatedTokenAddress` combined with the `mint` and `public key`, but this does not work with token accounts that are created using and older method (eg. Agora wallets).

In this setup, we fetch the account info for both the owner and destination and it will give back and array of token accounts, regardless of how they were created. 

The logic goes like this:
- If the owners token account is not found, it fails. 
- If the destination token account is not found, and `senderCreate` is not set, it fails.
- If the destination token account is not found, and `senderCreate` is set, it will use `getAssociatedTokenAddress` to derive the address.

Part of #507.