### PR TITLE
fix: support the case where token account and account owner are the same

### DIFF
--- a/libs/api/kinetic/data-access/src/lib/api-kinetic.service.ts
+++ b/libs/api/kinetic/data-access/src/lib/api-kinetic.service.ts
@@ -200,6 +200,8 @@ export class ApiKineticService implements OnModuleInit {
     const isTokenAccount = parsed?.type === 'account'
 
     const owner = isTokenAccount ? parsed.info.owner : null
+    // There are situations where the owner of the token account is the same as the account
+    const tokenAccountIsOwner = account?.toString() === owner?.toString()
 
     const result = {
       account: account.toString(),
@@ -208,11 +210,12 @@ export class ApiKineticService implements OnModuleInit {
       isTokenAccount,
       owner,
       program: accountInfo?.owner?.toString() ?? null,
-      tokens: !isMint && !isTokenAccount ? [] : null,
+      tokens: isMint || (isTokenAccount && !tokenAccountIsOwner) ? null : [],
     }
 
-    // We only want to get the token accounts if the account is not a mint or token account
-    if (isMint || isTokenAccount) {
+    // We don't want to get the token accounts if the account is a mint or token account
+    // Unless the token account is the same as the owner.
+    if (isMint || (isTokenAccount && !tokenAccountIsOwner)) {
       return result
     }
 


### PR DESCRIPTION
This patch fixes an issue where we could not send Kin from self-referencing accounts (token accounts that have the same public key as the account owner), like [this one](https://solscan.io/account/Don8L4DTVrUrRAcVTsFoCRqei5Mokde3CV3K9Ut4nAGZ).