### PR TITLE
fix: the Max Retries input field should never be disabled

### DIFF
--- a/libs/web/app/feature/src/lib/web-app-env-settings-solana.tsx
+++ b/libs/web/app/feature/src/lib/web-app-env-settings-solana.tsx
@@ -135,7 +135,6 @@ export function WebAppEnvSolanaTransactionForm({
             .
           </Text>
           <Field
-            isDisabled={!env.solanaTransactionMaxRetries}
             name="solanaTransactionMaxRetries"
             label="Max Retries"
             type="number"


### PR DESCRIPTION
This patch fixes the issue that would mark the Max Retries field as diabled if solanaTransactionMaxRetries was set to 0.