### PR TITLE
fix: make sure getBalance works with empty accounts

### DIFF
--- a/apps/sdk-e2e/src/integration/account-kinetic-sdk-e2e.spec.ts
+++ b/apps/sdk-e2e/src/integration/account-kinetic-sdk-e2e.spec.ts
@@ -101,10 +101,18 @@ describe('KineticSdk (e2e) - Account', () => {
     expect(tokenAccounts[0]).toBe('Ebq6K7xVh6PYQ8DrTQnD9fC91uQiyBMPGSV6JCG6GPdD')
   })
 
-  it('should throw an error when publicKey does not exit or is incorrect', async () => {
+  it('should throw an error when publicKey is incorrect', async () => {
     await expect(async () => await sdk.getBalance({ account: 'xx' })).rejects.toThrow(
       'accountId must be a valid PublicKey',
     )
+  })
+
+  it('should throw an error when publicKey does not exit', async () => {
+    const keypair = Keypair.random()
+    const res = await sdk.getBalance({ account: keypair.publicKey })
+
+    expect(res.balance).toEqual('0')
+    expect(res.tokens.length).toEqual(0)
   })
 
   it('should throw when try to create an account that already exists', async () => {

--- a/libs/api/account/data-access/src/lib/api-account.service.ts
+++ b/libs/api/account/data-access/src/lib/api-account.service.ts
@@ -66,7 +66,7 @@ export class ApiAccountService implements OnModuleInit {
     const mintAccounts = await this.kinetic.getMintAccounts(appKey, account, commitment, mints)
 
     // Get the balances for the token accounts
-    return solana.getMintAccountBalance(mintAccounts, commitment)
+    return solana.getMintAccountBalance(mints, mintAccounts, commitment)
   }
 
   async createAccount(req: Request, input: CreateAccountRequest): Promise<Transaction> {

--- a/libs/api/kinetic/data-access/src/lib/api-kinetic.service.ts
+++ b/libs/api/kinetic/data-access/src/lib/api-kinetic.service.ts
@@ -428,7 +428,7 @@ export class ApiKineticService implements OnModuleInit {
   ): Promise<MintAccounts> {
     return this.getTokenAccounts(appKey, account, mint.publicKey, commitment).then((accounts) => ({
       mint,
-      accounts,
+      accounts: accounts ?? [],
     }))
   }
 

--- a/libs/solana/src/lib/solana.spec.ts
+++ b/libs/solana/src/lib/solana.spec.ts
@@ -22,7 +22,11 @@ describe('solana', () => {
     ]
 
     try {
-      await solana.getMintAccountBalance(mintAccounts, Commitment.Confirmed)
+      await solana.getMintAccountBalance(
+        mintAccounts?.map((mint) => mint.mint),
+        mintAccounts,
+        Commitment.Confirmed,
+      )
     } catch (error) {
       expect(error.message).toBe(`No token accounts found for mint 4hUG2bJHubNDddLVsHjXBVTcuRskg7BSPuriudsbTCPa`)
     }
@@ -43,7 +47,11 @@ describe('solana', () => {
     ]
 
     try {
-      await solana.getMintAccountBalance(mintAccounts, Commitment.Confirmed)
+      await solana.getMintAccountBalance(
+        mintAccounts?.map((mint) => mint.mint),
+        mintAccounts,
+        Commitment.Confirmed,
+      )
     } catch (error) {
       expect(error.message).toBe(
         `No token accounts found for mints 4hUG2bJHubNDddLVsHjXBVTcuRskg7BSPuriudsbTCPa, 4hUG2bJHubNDddLVsHjXBVTcuRskg7BSPuriudsbTCPB`,

--- a/libs/solana/src/lib/solana.ts
+++ b/libs/solana/src/lib/solana.ts
@@ -18,6 +18,7 @@ import {
   removeDecimals,
 } from './helpers'
 import {
+  BalanceMint,
   BalanceMintMap,
   BalanceSummary,
   BalanceToken,
@@ -70,9 +71,11 @@ export class Solana {
     }
   }
 
-  async getMintAccountBalance(mintAccounts: MintAccounts[], commitment: Commitment): Promise<BalanceSummary> {
-    const mints = mintAccounts?.map((mint) => mint.mint)
-
+  async getMintAccountBalance(
+    mints: BalanceMint[],
+    mintAccounts: MintAccounts[],
+    commitment: Commitment,
+  ): Promise<BalanceSummary> {
     if (!mints?.length) {
       throw new Error(`getBalance: No mints provided.`)
     }


### PR DESCRIPTION
This patches fixes an issue introduced in #567 leading to an error 500 when checking `getBalance` on an empty account. 