### PR TITLE
fix: add compatibility for referenceId and referenceType fields

### DIFF
--- a/api-swagger.json
+++ b/api-swagger.json
@@ -676,6 +676,16 @@
           "reference": {
             "type": "string",
             "nullable": true
+          },
+          "referenceId": {
+            "type": "string",
+            "nullable": true,
+            "deprecated": true
+          },
+          "referenceType": {
+            "type": "string",
+            "nullable": true,
+            "deprecated": true
           }
         },
         "required": ["commitment", "account", "environment", "index", "mint"]
@@ -874,6 +884,16 @@
           "reference": {
             "type": "string",
             "nullable": true
+          },
+          "referenceId": {
+            "type": "string",
+            "nullable": true,
+            "deprecated": true
+          },
+          "referenceType": {
+            "type": "string",
+            "nullable": true,
+            "deprecated": true
           },
           "tx": {
             "type": "string"
@@ -1247,6 +1267,16 @@
           "reference": {
             "type": "string",
             "nullable": true
+          },
+          "referenceId": {
+            "type": "string",
+            "nullable": true,
+            "deprecated": true
+          },
+          "referenceType": {
+            "type": "string",
+            "nullable": true,
+            "deprecated": true
           },
           "tx": {
             "type": "string"

--- a/libs/api/account/data-access/src/lib/api-account.service.ts
+++ b/libs/api/account/data-access/src/lib/api-account.service.ts
@@ -1,6 +1,6 @@
 import { ApiAppService } from '@kin-kinetic/api/app/data-access'
 import { ApiCoreService } from '@kin-kinetic/api/core/data-access'
-import { getAppKey } from '@kin-kinetic/api/core/util'
+import { createReference, getAppKey } from '@kin-kinetic/api/core/util'
 import { ApiKineticService, CloseAccountRequest } from '@kin-kinetic/api/kinetic/data-access'
 import { Transaction } from '@kin-kinetic/api/transaction/data-access'
 import { Keypair } from '@kin-kinetic/keypair'
@@ -105,7 +105,7 @@ export class ApiAccountService implements OnModuleInit {
       lastValidBlockHeight: input.lastValidBlockHeight,
       mintPublicKey: mint?.mint?.address,
       processingStartedAt,
-      reference: input.reference,
+      reference: input.reference || createReference(input.referenceType, input.referenceId),
       solanaTransaction,
       source,
       tx: input.tx,

--- a/libs/api/account/data-access/src/lib/dto/create-account-request.dto.ts
+++ b/libs/api/account/data-access/src/lib/dto/create-account-request.dto.ts
@@ -14,6 +14,10 @@ export class CreateAccountRequest {
   mint: string
   @ApiProperty({ required: false, nullable: true })
   reference?: string
+  @ApiProperty({ nullable: true, required: false, deprecated: true })
+  referenceId?: string
+  @ApiProperty({ nullable: true, required: false, deprecated: true })
+  referenceType?: string
   @ApiProperty()
   tx: string
 }

--- a/libs/api/core/util/src/index.ts
+++ b/libs/api/core/util/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/create-reference'
 export * from './lib/ellipsify'
 export * from './lib/get-parse-app-key'
 export * from './lib/open-telemetry-sdk'

--- a/libs/api/core/util/src/lib/create-reference.ts
+++ b/libs/api/core/util/src/lib/create-reference.ts
@@ -1,0 +1,21 @@
+/**
+ * Migration to add the `type` column to the `reference` table
+ * This will be removed in v1.0.0
+ * @param {string} type
+ * @param {string} id
+ * @returns {string}
+ */
+export function createReference(type?: string, id?: string): string {
+  // If only type is provided, return type
+  if (type && !id) {
+    return type
+  }
+  // If only id is provided, return id
+  if (!type && id) {
+    return id
+  }
+  // If both type and id are provided, return type:id
+  if (type && id) {
+    return `${type}|${id}`
+  }
+}

--- a/libs/api/core/util/src/lib/public-key.pipe.ts
+++ b/libs/api/core/util/src/lib/public-key.pipe.ts
@@ -1,6 +1,5 @@
+import { HttpException, HttpStatus, Injectable, PipeTransform } from '@nestjs/common'
 import { PublicKey } from '@solana/web3.js'
-
-import { PipeTransform, Injectable, HttpException, HttpStatus } from '@nestjs/common'
 
 @Injectable()
 export class PublicKeyPipe implements PipeTransform {

--- a/libs/api/kinetic/data-access/src/lib/api-kinetic.service.ts
+++ b/libs/api/kinetic/data-access/src/lib/api-kinetic.service.ts
@@ -1,5 +1,5 @@
 import { ApiCoreService, AppEnvironment } from '@kin-kinetic/api/core/data-access'
-import { ellipsify, parseAppKey } from '@kin-kinetic/api/core/util'
+import { createReference, ellipsify, parseAppKey } from '@kin-kinetic/api/core/util'
 import { parseTransactionError } from '@kin-kinetic/api/kinetic/util'
 import { ApiSolanaService } from '@kin-kinetic/api/solana/data-access'
 import { ApiWebhookService, WebhookType } from '@kin-kinetic/api/webhook/data-access'
@@ -316,7 +316,7 @@ export class ApiKineticService implements OnModuleInit {
         blockhash,
         index: input.index,
         lastValidBlockHeight,
-        reference: input.reference,
+        reference: input.reference || createReference(input.referenceType, input.referenceId),
         signer: signer.solana,
         tokenAccount: tokenAccount.account,
       })
@@ -332,7 +332,7 @@ export class ApiKineticService implements OnModuleInit {
         ip,
         lastValidBlockHeight,
         mintPublicKey: mint?.mint?.address,
-        reference: input.reference,
+        reference: input.reference || createReference(input.referenceType, input.referenceId),
         processingStartedAt,
         solanaTransaction,
         source: input.account,

--- a/libs/api/kinetic/data-access/src/lib/dto/close-account-request.dto.ts
+++ b/libs/api/kinetic/data-access/src/lib/dto/close-account-request.dto.ts
@@ -14,4 +14,8 @@ export class CloseAccountRequest {
   mint: string
   @ApiProperty({ required: false, nullable: true })
   reference?: string
+  @ApiProperty({ nullable: true, required: false, deprecated: true })
+  referenceId?: string
+  @ApiProperty({ nullable: true, required: false, deprecated: true })
+  referenceType?: string
 }

--- a/libs/api/transaction/data-access/src/lib/dto/make-transfer-request.dto.ts
+++ b/libs/api/transaction/data-access/src/lib/dto/make-transfer-request.dto.ts
@@ -14,6 +14,10 @@ export class MakeTransferRequest {
   lastValidBlockHeight: number
   @ApiProperty({ nullable: true, required: false })
   reference?: string
+  @ApiProperty({ nullable: true, required: false, deprecated: true })
+  referenceId?: string
+  @ApiProperty({ nullable: true, required: false, deprecated: true })
+  referenceType?: string
   @ApiProperty()
   tx: string
 }

--- a/libs/sdk/src/generated/api.ts
+++ b/libs/sdk/src/generated/api.ts
@@ -407,6 +407,20 @@ export interface CloseAccountRequest {
    * @memberof CloseAccountRequest
    */
   reference?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof CloseAccountRequest
+   * @deprecated
+   */
+  referenceId?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof CloseAccountRequest
+   * @deprecated
+   */
+  referenceType?: string | null
 }
 /**
  *
@@ -633,6 +647,20 @@ export interface CreateAccountRequest {
    *
    * @type {string}
    * @memberof CreateAccountRequest
+   * @deprecated
+   */
+  referenceId?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof CreateAccountRequest
+   * @deprecated
+   */
+  referenceType?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof CreateAccountRequest
    */
   tx: string
 }
@@ -741,6 +769,20 @@ export interface MakeTransferRequest {
    * @memberof MakeTransferRequest
    */
   reference?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof MakeTransferRequest
+   * @deprecated
+   */
+  referenceId?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof MakeTransferRequest
+   * @deprecated
+   */
+  referenceType?: string | null
   /**
    *
    * @type {string}


### PR DESCRIPTION
This patch makes sure that Kinetic API v1.0.0-rc.17 is compatible with previous SDKs in terms of the `referenceId` and `referenceType` fields.